### PR TITLE
Package web client as self-hostable Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+.git
+.github
+.vscode
+.idea
+*.log
+.DS_Store
+.env
+.env.*

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,48 @@
+name: Publish image
+
+on:
+  push:
+    branches: [main, feat/docker]
+    tags: ['v*.*.*']
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/fortymm/web-client
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -2,7 +2,7 @@ name: Publish image
 
 on:
   push:
-    branches: [main, feat/docker]
+    branches: [main]
     tags: ['v*.*.*']
   workflow_dispatch:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM node:22-alpine AS builder
+FROM --platform=$BUILDPLATFORM node:22-alpine AS builder
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1.7
+
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine AS runtime
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY deploy/nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -1,75 +1,79 @@
-# React + TypeScript + Vite
+# FortyMM web client
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+The web client for FortyMM — built with Vite, React, TypeScript, TanStack Router, and Tailwind.
 
-Currently, two official plugins are available:
+## Develop
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
-
-## React Compiler
-
-The React Compiler is enabled on this template. See [this documentation](https://react.dev/learn/react-compiler) for more information.
-
-Note: This will impact Vite dev & build performances.
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```
+npm install
+npm run dev
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+Other scripts:
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+- `npm run build` — production build to `dist/`
+- `npm run preview` — serve the production build locally
+- `npm run lint` — run ESLint
+- `npm run typecheck` — generate the router tree and type-check
 
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+## Self-host
+
+A prebuilt image is published to GitHub Container Registry on every push to `main`:
+
+```
+docker run -d --name fortymm -p 8080:80 ghcr.io/fortymm/web-client:latest
+```
+
+Then visit http://localhost:8080.
+
+Images are multi-arch (`linux/amd64`, `linux/arm64`). Tags:
+
+- `latest` — tip of `main`
+- `sha-<short-sha>` — pinned to a specific commit
+- `v1.2.3`, `1.2`, `1` — semver tags for released versions
+
+### docker-compose.yml
+
+```yaml
+services:
+  web:
+    image: ghcr.io/fortymm/web-client:latest
+    restart: unless-stopped
+    ports:
+      - "8080:80"
+```
+
+### Behind a reverse proxy
+
+Caddy:
+
+```
+fortymm.example.com {
+    reverse_proxy localhost:8080
+}
+```
+
+nginx:
+
+```
+server {
+    listen 443 ssl;
+    server_name fortymm.example.com;
+
+    location / {
+        proxy_pass http://localhost:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+The container itself serves plain HTTP on port 80 — terminate TLS at your reverse proxy.
+
+### Build the image locally
+
+```
+docker build -t fortymm-web-client:dev .
+docker run --rm -p 8080:80 fortymm-web-client:dev
 ```

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,0 +1,27 @@
+server {
+  listen 80 default_server;
+  server_name _;
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location /assets/ {
+    access_log off;
+    expires 1y;
+    add_header Cache-Control "public, immutable";
+    try_files $uri =404;
+  }
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+
+  location = /index.html {
+    add_header Cache-Control "no-cache, no-store, must-revalidate";
+    expires 0;
+  }
+
+  gzip on;
+  gzip_vary on;
+  gzip_min_length 1024;
+  gzip_types text/plain text/css application/javascript application/json image/svg+xml font/woff2;
+}


### PR DESCRIPTION
## Summary

- Multi-stage `Dockerfile` (node:22-alpine builder on `$BUILDPLATFORM` + nginx:alpine runtime per target) packages the Vite build behind nginx with SPA fallback, hashed-asset `immutable` caching, and gzip.
- `.github/workflows/publish-image.yml` publishes multi-arch (`linux/amd64`, `linux/arm64`) images to `ghcr.io/fortymm/web-client` on push to `main` and on `v*.*.*` tags. Uses GHA layer cache for fast rebuilds.
- `README.md` rewritten: project intro, `Develop` commands, `Self-host` section with `docker run`, compose example, and Caddy/nginx reverse-proxy snippets.

Anyone can now self-host with:
```
docker run -d -p 8080:80 ghcr.io/fortymm/web-client:latest
```

## Verified

- Local build + run: SPA fallback works, hashed assets get `public, immutable; max-age=31536000`, missing `/assets/*` correctly 404s (doesn't fall through to index.html), HTML shell has `no-cache`.
- CI published multi-arch manifest (both `linux/amd64` and `linux/arm64`) to ghcr.io under the `feat-docker` and `sha-886bd9e` tags.
- Anonymous pull works (package is public).
- Reverse-proxied through Caddy at `https://fortymm.mightymoose.dev` — HTTP→HTTPS redirect + HTTP/2 serving correctly.

## One-time manual step (if not already done)

Flip the ghcr.io package to public visibility: https://github.com/orgs/fortymm/packages/container/web-client/settings → Danger Zone → Change visibility → Public.

## Test plan

- [ ] Merge to `main` and confirm the workflow publishes `latest`, `main`, and `sha-<short>` tags
- [ ] `docker pull ghcr.io/fortymm/web-client:latest` on a clean machine and run — landing page renders at http://localhost:8080
- [ ] Hit an arbitrary deep-link path (e.g. `/any/made-up/route`) — should render the app, not nginx 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)