### PR TITLE
Scaffold state-driven player dashboard

### DIFF
--- a/issues.md
+++ b/issues.md
@@ -1,0 +1,57 @@
+# Dashboard follow-ups
+
+Leftover review findings from PR #4 (after addressing nav a11y and inline-token refactor). Ordered by severity.
+
+## Medium
+
+### 1. `Mono` still allocates a fresh style object on every render
+`src/components/dashboard/primitives.tsx` — `Mono` is used ~50× across the tree and each render builds an inline `style` object for `fontSize` / `fontWeight` (color is now opt-in after the simplify pass). It reinvents Tailwind's text utilities with a runtime API. Options:
+- Delete `Mono` entirely and inline `font-mono tabular-nums tracking-[-0.01em] text-[Npx] font-bold text-chalk-300` at call sites.
+- Convert to cva variants mirroring `Button`: `<Mono size="xs" tone="muted">`.
+- Narrow the API to only the sizes actually used and map each to a class.
+
+### 2. Fake keyboard shortcuts in `LiveMatchScoreboard`
+`src/components/dashboard/live-match.tsx` — the `+1 for me` / `+1 for opponent` buttons render `SPACE` and `N` kbd hints but no global listener exists. Either:
+- Wire up a `useEffect` that binds `keydown` to the same onClick handlers (ideally via a `useHotkey` primitive).
+- Or drop the kbd labels until scoring is wired to real state.
+
+### 3. `Avatar` tone="ball" contrast at small sizes
+`src/components/dashboard/primitives.tsx` → `AVATAR_TONES.ball` uses `fg: '#111'` on an orange gradient. At 32px (topbar avatar) and 34px (club feed announce row) this is ~3.0–3.5:1 — fails WCAG AA for small text. Run through a contrast checker, consider bumping to `#0B0D12` (`--color-ink-950`) or widening the outer stop to a deeper orange.
+
+### 4. Hardcoded greeting for `in_tournament_playing`
+`src/components/dashboard/greeting.tsx` — the copy `` `Game 4, ${firstName}. Lead at 2–1.` `` doesn't read from `LIVE_MATCH.games`. If mock data changes the greeting silently lies. Derive the game number (`games.length`) and games-won tally from `LIVE_MATCH`.
+
+## Low
+
+### 5. Dead mock-data fields in `data.ts`
+Never read anywhere in the tree — drop or display:
+- `ME.handle`, `ME.rank.region`
+- `TOURNAMENT.standings`, `TOURNAMENT.bracket.remaining`
+- `TD_EVENT.role` (panel hardcodes "DIRECTOR CONTROL")
+- `TD_EVENT.schedule.onTime`, `.behind`, `.ahead`
+- `TD_EVENT.solver.horizon`
+
+### 6. Redundant `cursor-pointer` on `<button>` elements
+Buttons already get pointer cursors in every modern browser. Drop from:
+- `primitives.tsx` → `TextLink`
+- `topbar.tsx` → state-cycle button, Search/Bell icon buttons, Dashboard Link
+- `td-panel.tsx` → Call-to-court button
+
+### 7. `PlayerBlock` splits names by space with `key={i}`
+`live-match.tsx` — `name.split(' ').map((w, i) => <div key={i}>{w}</div>)` produces "Van / Der / Berg" on three separate lines for compound surnames. Cosmetic, but worth a `TODO` or a `whitespace-nowrap` variant that keeps hyphenated/compound names together.
+
+### 8. No test runner
+The project has no `vitest`/`jest` configured. The six-state matrix + the state machine + `LiveMatchScoreboard` game-derivation logic is the first place in the repo where tests would pay off:
+- Smoke: each state renders without throwing.
+- Interaction: cycling through all six from the topbar doesn't warn.
+- Derivation: `myGamesWon`/`theirGamesWon` match curated fixtures.
+
+### 9. `shadow-[0_0_32px_rgba(...)]` arbitrary shadows still carry raw rgba
+`primitives.tsx` (Card live), `tournament-panel.tsx` (PATH_COLORS.live), `td-panel.tsx` (TDCourtTile.live). Tailwind v4 doesn't have a clean `shadow-{color}/opacity` with custom blur. Options:
+- Define named shadow tokens in `index.css` `@theme` (`--shadow-live-ball-glow`, etc.) and use `shadow-live-ball-glow`.
+- Use `color-mix(in oklab, var(--color-X) NN%, transparent)` inside the arbitrary — verbose but token-honest.
+
+## Notes for future routes
+
+- **Don't copy `primitives.tsx` wholesale.** `Mono`/`Pill`/`Avatar` should move toward cva variants matching `Button` before they're reused.
+- **Consolidate the dashboard `Ball` with marketing `Logo`.** The SVG is nearly identical; `Logo` adds a cue-ball highlight ellipse the dashboard design omits. A `<Ball highlight={false} />` prop on one shared component would end the duplication.

--- a/src/components/dashboard/ball.tsx
+++ b/src/components/dashboard/ball.tsx
@@ -1,0 +1,31 @@
+import type { CSSProperties } from 'react'
+import { useId } from 'react'
+
+type BallProps = {
+  size?: number
+  live?: boolean
+  style?: CSSProperties
+}
+
+export function Ball({ size = 28, live = false, style }: BallProps) {
+  const gradientId = useId()
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 80 80"
+      aria-hidden
+      focusable={false}
+      style={style}
+    >
+      <defs>
+        <radialGradient id={gradientId} cx="35%" cy="35%" r="65%">
+          <stop offset="0%" stopColor={live ? '#8CFFD4' : '#FFB57A'} />
+          <stop offset="55%" stopColor={live ? '#00E29A' : '#FF7A1A'} />
+          <stop offset="100%" stopColor={live ? '#009968' : '#B94700'} />
+        </radialGradient>
+      </defs>
+      <circle cx="40" cy="40" r="36" fill={`url(#${gradientId})`} />
+    </svg>
+  )
+}

--- a/src/components/dashboard/club-feed.tsx
+++ b/src/components/dashboard/club-feed.tsx
@@ -1,3 +1,4 @@
+import { cn } from '@/lib/utils'
 import { CLUB_FEED, ME } from './data'
 import { Avatar, Card, Mono, SectionHeader, TextLink } from './primitives'
 
@@ -32,12 +33,10 @@ export function ClubFeed() {
               {f.meta && (
                 <Mono
                   size={11}
-                  color={
-                    f.tone === 'win'
-                      ? 'var(--color-serve-500)'
-                      : 'var(--color-chalk-300)'
-                  }
-                  className="mt-0.5 block"
+                  className={cn(
+                    'mt-0.5 block',
+                    f.tone === 'win' ? 'text-serve-500' : 'text-chalk-300',
+                  )}
                 >
                   {f.meta}
                 </Mono>
@@ -45,8 +44,7 @@ export function ClubFeed() {
             </div>
             <Mono
               size={10}
-              color="var(--color-chalk-300)"
-              className="mt-1 shrink-0 whitespace-nowrap"
+              className="mt-1 shrink-0 whitespace-nowrap text-chalk-300"
             >
               {f.when.toUpperCase()}
             </Mono>

--- a/src/components/dashboard/club-feed.tsx
+++ b/src/components/dashboard/club-feed.tsx
@@ -1,0 +1,58 @@
+import { CLUB_FEED, ME } from './data'
+import { Avatar, Card, Mono, SectionHeader, TextLink } from './primitives'
+
+export function ClubFeed() {
+  return (
+    <Card>
+      <div className="px-5 pt-4.5 pb-3.5">
+        <SectionHeader
+          eyebrow={`${ME.club.toUpperCase()} · FEED`}
+          title="Club activity"
+          right={<TextLink>Open club →</TextLink>}
+        />
+      </div>
+      {CLUB_FEED.map((f) => {
+        const tone =
+          f.tone === 'announce'
+            ? 'ball'
+            : f.tone === 'milestone'
+              ? 'serve'
+              : 'ink'
+        return (
+          <div
+            key={f.id}
+            className="flex items-start gap-3 border-t border-ink-600 px-5 py-3.5"
+          >
+            <Avatar initials={f.initials} size={34} tone={tone} />
+            <div className="flex-1 leading-[1.4]">
+              <div className="text-[13px] text-chalk-100">
+                <span className="font-semibold text-chalk-50">{f.who}</span>{' '}
+                {f.text}
+              </div>
+              {f.meta && (
+                <Mono
+                  size={11}
+                  color={
+                    f.tone === 'win'
+                      ? 'var(--color-serve-500)'
+                      : 'var(--color-chalk-300)'
+                  }
+                  className="mt-0.5 block"
+                >
+                  {f.meta}
+                </Mono>
+              )}
+            </div>
+            <Mono
+              size={10}
+              color="var(--color-chalk-300)"
+              className="mt-1 shrink-0 whitespace-nowrap"
+            >
+              {f.when.toUpperCase()}
+            </Mono>
+          </div>
+        )
+      })}
+    </Card>
+  )
+}

--- a/src/components/dashboard/data.ts
+++ b/src/components/dashboard/data.ts
@@ -1,0 +1,440 @@
+export type DashboardState =
+  | 'idle'
+  | 'live_match'
+  | 'in_tournament'
+  | 'in_tournament_playing'
+  | 'td'
+  | 'td_playing'
+
+export const DASHBOARD_STATES = [
+  'idle',
+  'live_match',
+  'in_tournament',
+  'in_tournament_playing',
+  'td',
+  'td_playing',
+] as const satisfies readonly DashboardState[]
+
+export type PathResult = 'W' | 'L' | 'bye' | 'live' | 'upcoming' | 'locked'
+
+export type GameScore = {
+  me: number
+  them: number
+  winner: 'me' | 'them' | null
+}
+
+export type Player = {
+  name: string
+  seed: number
+  rating: number
+}
+
+export type Opponent = Player & {
+  club: string
+  hand: 'Right' | 'Left'
+  style: string
+  h2h: { w: number; l: number }
+}
+
+export type LiveMatch = {
+  court: number
+  round: string
+  event: string
+  bestOf: number
+  serving: 'me' | 'them'
+  games: GameScore[]
+  opponent: Opponent
+  me: Player
+  timer: string
+  startedAt: string
+}
+
+export type PathStep = {
+  round: string
+  opponent: string
+  score: string | null
+  result: PathResult
+  games?: string
+  detail?: string
+  eta?: string
+}
+
+export type UpNext = {
+  court: number
+  time: string
+  a: string
+  b: string
+  round: string
+  you: boolean
+  note?: string
+}
+
+export type Tournament = {
+  name: string
+  venue: string
+  day: number
+  ofDays: number
+  format: string
+  status: string
+  myPath: PathStep[]
+  upNext: UpNext[]
+  bracket: { yourSeed: number; remaining: number; toWin: number }
+  standings: { placed: number; of: number; reachedAtLeast: string }
+}
+
+export type NeedsYouKind = 'score' | 'call' | 'nudge'
+
+export type CourtStatus =
+  | {
+      n: number
+      state: 'live'
+      a: string
+      b: string
+      g: number
+      sa: number
+      sb: number
+      win: 'a' | 'b' | null
+      you?: boolean
+    }
+  | { n: number; state: 'open'; next: string }
+  | { n: number; state: 'setup' }
+
+export type TDEvent = {
+  name: string
+  role: string
+  courts: { total: number; live: number; open: number; setup: number }
+  schedule: { onTime: boolean; drift: string; behind: number; ahead: number }
+  players: { checkedIn: number; total: number; noShow: number }
+  matches: { done: number; live: number; upcoming: number; unscored: number }
+  solver: {
+    status: string
+    horizon: string
+    ms: number
+    conflicts: number
+  }
+  needsYou: {
+    kind: NeedsYouKind
+    label: string
+    detail: string
+    urgent: boolean
+  }[]
+  courtStatus: CourtStatus[]
+}
+
+export type RecentMatch = {
+  when: string
+  opponent: string
+  result: 'W' | 'L'
+  score: string
+  delta: number
+  event: string
+}
+
+export type ClubFeedItem = {
+  id: number
+  who: string
+  initials: string
+  text: string
+  meta: string
+  when: string
+  tone?: 'win' | 'announce' | 'milestone'
+}
+
+export type StateLabel = {
+  key: DashboardState
+  label: string
+  sub: string
+}
+
+export const ME = {
+  name: 'Thuy Nguyen',
+  handle: '@thuy',
+  initials: 'TN',
+  rating: 1847,
+  ratingDelta: +23,
+  club: 'Eastside TTC',
+  record: { w: 42, l: 18 },
+  streak: 4,
+  rank: { club: 3, region: 42 },
+} as const
+
+export const LIVE_MATCH: LiveMatch = {
+  court: 3,
+  round: 'R16',
+  event: 'Spring Open 2026',
+  bestOf: 5,
+  serving: 'me',
+  games: [
+    { me: 11, them: 7, winner: 'me' },
+    { me: 9, them: 11, winner: 'them' },
+    { me: 11, them: 8, winner: 'me' },
+    { me: 6, them: 4, winner: null },
+  ],
+  opponent: {
+    name: 'Rafael Silva',
+    seed: 16,
+    rating: 1792,
+    club: 'Riverside TT',
+    hand: 'Right',
+    style: 'Defensive chopper',
+    h2h: { w: 2, l: 1 },
+  },
+  me: {
+    name: 'Thuy Nguyen',
+    seed: 1,
+    rating: 1847,
+  },
+  timer: '23:14',
+  startedAt: '6:42 PM',
+}
+
+export const TOURNAMENT: Tournament = {
+  name: 'Spring Open 2026',
+  venue: 'Eastside Sports Complex',
+  day: 2,
+  ofDays: 2,
+  format: '64-draw, single elim',
+  status: 'Day 2 · Quarterfinals soon',
+  myPath: [
+    { round: 'R64', opponent: 'Bye', score: null, result: 'bye' },
+    {
+      round: 'R32',
+      opponent: 'L. Tran',
+      score: '3–0',
+      result: 'W',
+      games: '11-6, 11-8, 11-9',
+    },
+    {
+      round: 'R16',
+      opponent: 'R. Silva',
+      score: '2–1',
+      result: 'live',
+      detail: 'game 4 · 6-4',
+    },
+    {
+      round: 'QF',
+      opponent: 'Winner R16·4',
+      score: null,
+      result: 'upcoming',
+      eta: '~7:40 PM · Court 3',
+    },
+    { round: 'SF', opponent: 'TBD', score: null, result: 'locked' },
+    { round: 'F', opponent: 'TBD', score: null, result: 'locked' },
+  ],
+  upNext: [
+    {
+      court: 3,
+      time: '7:42 PM',
+      a: 'Nguyen, T.',
+      b: 'Winner R16·4',
+      round: 'QF',
+      you: true,
+      note: 'after your current match',
+    },
+    {
+      court: 2,
+      time: '7:55 PM',
+      a: 'Kim, H.',
+      b: 'Dubois, C.',
+      round: 'QF',
+      you: false,
+    },
+    {
+      court: 1,
+      time: '8:20 PM',
+      a: 'Tran, L.',
+      b: 'Rossi, G.',
+      round: 'QF',
+      you: false,
+    },
+  ],
+  bracket: { yourSeed: 1, remaining: 8, toWin: 3 },
+  standings: { placed: 1, of: 64, reachedAtLeast: 'R16' },
+}
+
+export const TD_EVENT: TDEvent = {
+  name: 'Spring Open 2026',
+  role: 'Tournament Director',
+  courts: { total: 8, live: 4, open: 2, setup: 2 },
+  schedule: { onTime: true, drift: '+2m', behind: 0, ahead: 0 },
+  players: { checkedIn: 58, total: 64, noShow: 1 },
+  matches: { done: 48, live: 4, upcoming: 12, unscored: 1 },
+  solver: { status: 'optimal', horizon: '4h 14m', ms: 234, conflicts: 0 },
+  needsYou: [
+    {
+      kind: 'score',
+      label: 'Unscored match — Court 5',
+      detail: 'Finished 18 min ago',
+      urgent: true,
+    },
+    {
+      kind: 'call',
+      label: 'Call Kim, H. vs Ali, R.',
+      detail: 'Court 4 · in 3 min',
+      urgent: false,
+    },
+    {
+      kind: 'nudge',
+      label: "Chen, W. hasn't checked in",
+      detail: 'QF at 7:55 PM',
+      urgent: true,
+    },
+  ],
+  courtStatus: [
+    {
+      n: 1,
+      state: 'live',
+      a: 'Tran, L.',
+      b: 'Rossi, G.',
+      g: 4,
+      sa: 11,
+      sb: 8,
+      win: 'a',
+    },
+    {
+      n: 2,
+      state: 'live',
+      a: 'Okafor, D.',
+      b: 'Johansen, A.',
+      g: 2,
+      sa: 9,
+      sb: 11,
+      win: 'b',
+    },
+    {
+      n: 3,
+      state: 'live',
+      a: 'Nguyen, T.',
+      b: 'Silva, R.',
+      g: 4,
+      sa: 6,
+      sb: 4,
+      win: null,
+      you: true,
+    },
+    {
+      n: 4,
+      state: 'live',
+      a: 'Chen, W.',
+      b: 'Park, J.',
+      g: 1,
+      sa: 7,
+      sb: 6,
+      win: 'a',
+    },
+    { n: 5, state: 'open', next: 'Kim, H. vs Ali, R.' },
+    { n: 6, state: 'open', next: 'Dubois, C. vs Patel, M.' },
+    { n: 7, state: 'setup' },
+    { n: 8, state: 'setup' },
+  ],
+}
+
+export const RECENT_MATCHES: RecentMatch[] = [
+  {
+    when: 'Yesterday',
+    opponent: 'L. Tran',
+    result: 'W',
+    score: '3–0',
+    delta: +14,
+    event: 'Spring Open · R32',
+  },
+  {
+    when: 'Yesterday',
+    opponent: 'R. Silva',
+    result: 'W',
+    score: '3–2',
+    delta: +18,
+    event: 'Club ladder',
+  },
+  {
+    when: 'Sat, Apr 12',
+    opponent: 'M. Patel',
+    result: 'L',
+    score: '1–3',
+    delta: -9,
+    event: 'Friendly',
+  },
+  {
+    when: 'Fri, Apr 11',
+    opponent: 'D. Okafor',
+    result: 'W',
+    score: '3–1',
+    delta: +11,
+    event: 'Club ladder',
+  },
+  {
+    when: 'Thu, Apr 10',
+    opponent: 'J. Park',
+    result: 'W',
+    score: '3–2',
+    delta: +8,
+    event: 'Friendly',
+  },
+]
+
+export const CLUB_FEED: ClubFeedItem[] = [
+  {
+    id: 1,
+    who: 'Mika',
+    initials: 'MK',
+    text: 'logged a match vs D. Okafor',
+    meta: 'W 3–1 · +11',
+    when: '12 min ago',
+    tone: 'win',
+  },
+  {
+    id: 2,
+    who: 'Rafael',
+    initials: 'RS',
+    text: 'checked in for Spring Open',
+    meta: 'seed #16',
+    when: '1 hr ago',
+  },
+  {
+    id: 3,
+    who: 'Eastside TTC',
+    initials: '●',
+    text: 'Wed night league needs 2 more — anyone in?',
+    meta: '',
+    when: '3 hr ago',
+    tone: 'announce',
+  },
+  {
+    id: 4,
+    who: 'Hanna',
+    initials: 'HK',
+    text: 'hit 1900 for the first time',
+    meta: '+42 streak',
+    when: 'yesterday',
+    tone: 'milestone',
+  },
+]
+
+export const STATE_LABELS: Record<DashboardState, StateLabel> = {
+  idle: { key: 'idle', label: 'Idle', sub: 'No match. No tournament.' },
+  live_match: {
+    key: 'live_match',
+    label: 'Live match',
+    sub: "You're on court right now.",
+  },
+  in_tournament: {
+    key: 'in_tournament',
+    label: 'In tournament',
+    sub: 'Between matches.',
+  },
+  in_tournament_playing: {
+    key: 'in_tournament_playing',
+    label: 'In tournament · playing',
+    sub: 'On court, in an active draw.',
+  },
+  td: {
+    key: 'td',
+    label: 'Tournament director',
+    sub: 'Running an event.',
+  },
+  td_playing: {
+    key: 'td_playing',
+    label: 'TD · also playing',
+    sub: "You're on court in your own event.",
+  },
+}

--- a/src/components/dashboard/footer.tsx
+++ b/src/components/dashboard/footer.tsx
@@ -10,7 +10,7 @@ export function DashboardFooter() {
       </span>
       <span className="text-[12px]">Play more. Pay never.</span>
       <div className="flex-1" />
-      <Mono size={10} color="var(--color-chalk-300)">
+      <Mono size={10} className="text-chalk-300">
         v 2026.04 · NO ADS · NO TRACKING
       </Mono>
     </footer>

--- a/src/components/dashboard/footer.tsx
+++ b/src/components/dashboard/footer.tsx
@@ -1,0 +1,18 @@
+import { Ball } from './ball'
+import { Mono } from './primitives'
+
+export function DashboardFooter() {
+  return (
+    <footer className="flex items-center gap-5 border-t border-ink-600 px-10 pt-8 pb-10 text-chalk-300">
+      <Ball size={20} />
+      <span className="font-display text-[16px] tracking-[0.05em] text-chalk-100">
+        FORTYMM<span className="text-ball-500">.</span>
+      </span>
+      <span className="text-[12px]">Play more. Pay never.</span>
+      <div className="flex-1" />
+      <Mono size={10} color="var(--color-chalk-300)">
+        v 2026.04 · NO ADS · NO TRACKING
+      </Mono>
+    </footer>
+  )
+}

--- a/src/components/dashboard/greeting.tsx
+++ b/src/components/dashboard/greeting.tsx
@@ -1,0 +1,119 @@
+import { useMemo } from 'react'
+import { Calendar, Plus } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import type { DashboardState } from './data'
+import { ME, STATE_LABELS, TD_EVENT, TOURNAMENT } from './data'
+import { Mono, Overline } from './primitives'
+
+type GreetingCopy = { line: string; sub: string }
+
+function timeOfDay(h: number) {
+  if (h < 5) return 'Late'
+  if (h < 12) return 'Morning'
+  if (h < 17) return 'Afternoon'
+  if (h < 21) return 'Evening'
+  return 'Late'
+}
+
+const GREETINGS: Record<
+  DashboardState,
+  (firstName: string, tod: string) => GreetingCopy
+> = {
+  idle: (firstName, tod) => ({
+    line: `${tod}, ${firstName}.`,
+    sub: 'Nothing on the schedule. Go find a match.',
+  }),
+  live_match: (firstName) => ({
+    line: `You're on court, ${firstName}.`,
+    sub: 'Everything else can wait.',
+  }),
+  in_tournament: (firstName, tod) => ({
+    line: `${tod}, ${firstName}.`,
+    sub: `Day ${TOURNAMENT.day} of ${TOURNAMENT.ofDays} · ${TOURNAMENT.name}.`,
+  }),
+  in_tournament_playing: (firstName) => ({
+    line: `Game 4, ${firstName}. Lead at 2–1.`,
+    sub: `${TOURNAMENT.name} · ${TOURNAMENT.myPath[2].round}.`,
+  }),
+  td: (_firstName, tod) => ({
+    line: `${tod}, director.`,
+    sub: `${TD_EVENT.name} · ${TD_EVENT.matches.done}/${
+      TD_EVENT.matches.done +
+      TD_EVENT.matches.live +
+      TD_EVENT.matches.upcoming
+    } matches done.`,
+  }),
+  td_playing: () => ({
+    line: `You're on court AND running the show.`,
+    sub: `Both hats on. Full-bleed is off so you can see the floor.`,
+  }),
+}
+
+export function Greeting({ state }: { state: DashboardState }) {
+  const { tod, todayLabel } = useMemo(() => {
+    const now = new Date()
+    return {
+      tod: timeOfDay(now.getHours()),
+      todayLabel: now.toLocaleDateString('en-US', {
+        weekday: 'long',
+        month: 'long',
+        day: 'numeric',
+      }),
+    }
+  }, [])
+
+  const firstName = ME.name.split(' ')[0]
+  const g = GREETINGS[state](firstName, tod)
+
+  return (
+    <div className="flex flex-wrap items-end justify-between gap-8 px-10 pt-7 pb-5">
+      <div className="min-w-0 flex-[1_1_420px]">
+        <Overline className="mb-2">
+          <span className="ball-dot mr-2 inline-block size-2 align-middle" />
+          {todayLabel} · {STATE_LABELS[state].label}
+        </Overline>
+        <div
+          className="mb-3 max-w-[720px] font-display uppercase tracking-[0.01em] text-chalk-50"
+          style={{
+            fontSize: 'clamp(36px, 4.2vw, 52px)',
+            lineHeight: 1.02,
+            textWrap: 'balance',
+          }}
+        >
+          {g.line}
+        </div>
+        <div className="max-w-[640px] font-sans text-[15px] text-chalk-300">
+          {g.sub}
+        </div>
+      </div>
+      <div className="flex shrink-0 gap-2 self-end">
+        <Button variant="ghost-secondary">
+          <Calendar />
+          This week
+        </Button>
+        <Button variant="primary">
+          <Plus />
+          Log a match
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export function ContextRow({ state }: { state: DashboardState }) {
+  const inTourney = state === 'in_tournament_playing'
+  return (
+    <div className="flex items-center gap-4 border-b border-ink-600 bg-ink-950 px-10 py-3.5">
+      <Overline>{inTourney ? 'CURRENTLY' : 'NOT MUCH ELSE TO SEE'}</Overline>
+      <div className="font-sans text-[14px] text-chalk-100">
+        {inTourney
+          ? "The dashboard is quiet while you're on court. QF match is locked in below — everything else can wait."
+          : "When you're on court, the scoreboard takes over. We'll get out of your way."}
+      </div>
+      <div className="flex-1" />
+      <Mono size={11} color="var(--color-chalk-300)">
+        AUTO-FULL-BLEED
+      </Mono>
+    </div>
+  )
+}

--- a/src/components/dashboard/greeting.tsx
+++ b/src/components/dashboard/greeting.tsx
@@ -111,7 +111,7 @@ export function ContextRow({ state }: { state: DashboardState }) {
           : "When you're on court, the scoreboard takes over. We'll get out of your way."}
       </div>
       <div className="flex-1" />
-      <Mono size={11} color="var(--color-chalk-300)">
+      <Mono size={11} className="text-chalk-300">
         AUTO-FULL-BLEED
       </Mono>
     </div>

--- a/src/components/dashboard/idle-hero.tsx
+++ b/src/components/dashboard/idle-hero.tsx
@@ -1,0 +1,59 @@
+import { PencilLine, Trophy, Users } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Ball } from './ball'
+import { Card, Overline } from './primitives'
+
+export function IdleHero() {
+  return (
+    <Card className="relative overflow-hidden">
+      <div
+        className="fortymm-grid-bg pointer-events-none absolute inset-0 opacity-50"
+        style={{
+          maskImage:
+            'radial-gradient(ellipse at 30% 40%, #000, transparent 75%)',
+          WebkitMaskImage:
+            'radial-gradient(ellipse at 30% 40%, #000, transparent 75%)',
+        }}
+      />
+      <div className="relative px-[34px] py-8">
+        <div className="pointer-events-none absolute top-6 right-6 opacity-90">
+          <Ball
+            size={96}
+            style={{ filter: 'drop-shadow(0 0 40px rgba(255,122,26,0.35))' }}
+          />
+        </div>
+        <div className="pr-[120px]">
+          <Overline className="mb-3">NOTHING ON YOUR SCHEDULE</Overline>
+          <div
+            className="mb-7 font-display uppercase tracking-[0.01em] text-chalk-50"
+            style={{ fontSize: 40, lineHeight: 1.05 }}
+          >
+            Go play.
+            <br />
+            <span className="text-ball-500">Log it when you're back.</span>
+          </div>
+          <div className="mb-4 max-w-[520px] text-[14px] text-chalk-300">
+            No live match. No active tournament. Your club has{' '}
+            <span className="text-chalk-50">3 ladder matches</span> waiting and
+            there are <span className="text-chalk-50">2 tournaments</span> open
+            for registration this month.
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button variant="primary">
+            <PencilLine />
+            Log match
+          </Button>
+          <Button variant="ghost-secondary">
+            <Users />
+            Find opponent
+          </Button>
+          <Button variant="ghost">
+            <Trophy />
+            Tournaments
+          </Button>
+        </div>
+      </div>
+    </Card>
+  )
+}

--- a/src/components/dashboard/live-match.tsx
+++ b/src/components/dashboard/live-match.tsx
@@ -1,0 +1,513 @@
+import {
+  Flag,
+  Maximize2,
+  Minimize2,
+  Plus,
+  RotateCcw,
+  Share2,
+  UserPlus,
+  X,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import type { GameScore, LiveMatch } from './data'
+import { LiveDot, Mono, Overline, Pill } from './primitives'
+
+type LiveMatchScoreboardProps = {
+  match: LiveMatch
+  onExit?: () => void
+  compact?: boolean
+}
+
+export function LiveMatchScoreboard({
+  match,
+  onExit,
+  compact = false,
+}: LiveMatchScoreboardProps) {
+  const currentIndex = match.games.findIndex((g) => g.winner === null)
+  const currentGame =
+    currentIndex >= 0
+      ? match.games[currentIndex]
+      : match.games[match.games.length - 1]
+  const myGamesWon = match.games.filter((g) => g.winner === 'me').length
+  const theirGamesWon = match.games.filter((g) => g.winner === 'them').length
+  const myServe = match.serving === 'me'
+
+  if (compact) {
+    return (
+      <LiveMatchHeroCard
+        match={match}
+        currentGame={currentGame}
+        myGamesWon={myGamesWon}
+        theirGamesWon={theirGamesWon}
+      />
+    )
+  }
+
+  return (
+    <div className="relative overflow-hidden border-b border-ink-600 bg-ink-950">
+      <div
+        className="fortymm-grid-bg absolute inset-0 opacity-[0.35]"
+        style={{
+          maskImage:
+            'radial-gradient(ellipse at 50% 40%, #000 30%, transparent 75%)',
+          WebkitMaskImage:
+            'radial-gradient(ellipse at 50% 40%, #000 30%, transparent 75%)',
+        }}
+      />
+      <div
+        className="pointer-events-none absolute inset-x-[-20%] top-[-40%] h-[60%]"
+        style={{
+          background:
+            'radial-gradient(ellipse at 50% 100%, rgba(255,122,26,0.12), transparent 60%)',
+        }}
+      />
+
+      <div className="relative px-10 pt-5 pb-7">
+        <div className="mb-5 flex flex-wrap items-center gap-3.5">
+          <Pill tone="live" icon={<LiveDot size={7} />}>
+            ON COURT · LIVE
+          </Pill>
+          <div className="inline-flex items-center gap-2 font-mono text-[12px] tracking-[0.1em] text-chalk-300">
+            <span className="text-chalk-100">{match.event}</span>
+            <span>·</span>
+            <span>{match.round}</span>
+            <span>·</span>
+            <span>COURT {match.court}</span>
+            <span>·</span>
+            <span>BEST OF {match.bestOf}</span>
+          </div>
+          <div className="flex-1" />
+          <Mono size={13} color="var(--color-chalk-300)">
+            ⌚ {match.timer} since {match.startedAt}
+          </Mono>
+          <Button variant="ghost-secondary" size="sm" onClick={onExit}>
+            <Minimize2 />
+            Minimise
+          </Button>
+          <Button variant="secondary" size="sm">
+            <Share2 />
+            Share court
+          </Button>
+        </div>
+
+        <div
+          className="grid items-center gap-8 px-0 pt-2.5 pb-5"
+          style={{ gridTemplateColumns: '1fr auto 1fr' }}
+        >
+          <PlayerBlock
+            side="left"
+            name={match.me.name}
+            seed={match.me.seed}
+            rating={match.me.rating}
+            serving={myServe}
+            gamesWon={myGamesWon}
+            bestOf={match.bestOf}
+          />
+
+          <CenterScore
+            myScore={currentGame.me}
+            theirScore={currentGame.them}
+            gameLabel={`GAME ${match.games.length}`}
+          />
+
+          <PlayerBlock
+            side="right"
+            name={match.opponent.name}
+            seed={match.opponent.seed}
+            rating={match.opponent.rating}
+            serving={!myServe}
+            gamesWon={theirGamesWon}
+            bestOf={match.bestOf}
+          />
+        </div>
+
+        <GameStrip games={match.games} bestOf={match.bestOf} />
+
+        <div className="mt-5 flex flex-wrap items-center gap-2.5">
+          <Button variant="primary" size="lg">
+            <Plus />
+            +1 for me
+            <Mono size={11} color="var(--color-ink-950)" className="ml-1">
+              SPACE
+            </Mono>
+          </Button>
+          <Button variant="secondary" size="lg">
+            <Plus />
+            +1 for opponent
+            <Mono size={11} color="var(--color-chalk-300)" className="ml-1">
+              N
+            </Mono>
+          </Button>
+          <Button variant="ghost-secondary" size="lg">
+            <RotateCcw />
+            Undo
+          </Button>
+          <div className="flex-1" />
+          <Button variant="ghost-secondary" size="lg">
+            <Flag />
+            Call let
+          </Button>
+          <Button variant="ghost-secondary" size="lg">
+            <UserPlus />
+            Call umpire
+          </Button>
+          <Button
+            variant="ghost-secondary"
+            size="lg"
+            className="border-[rgba(255,77,109,0.4)] text-loss hover:bg-loss/10 hover:text-loss"
+          >
+            <X />
+            Retire
+          </Button>
+        </div>
+
+        <OpponentStrip match={match} />
+      </div>
+    </div>
+  )
+}
+
+type PlayerBlockProps = {
+  side: 'left' | 'right'
+  name: string
+  seed: number
+  rating: number
+  serving: boolean
+  gamesWon: number
+  bestOf: number
+}
+
+function PlayerBlock({
+  side,
+  name,
+  seed,
+  rating,
+  serving,
+  gamesWon,
+  bestOf,
+}: PlayerBlockProps) {
+  const needed = Math.ceil(bestOf / 2)
+  const isLeft = side === 'left'
+  const alignItems = isLeft ? 'items-start' : 'items-end'
+  const flexDir = isLeft ? 'flex-row' : 'flex-row-reverse'
+  const textAlign = isLeft ? 'text-left' : 'text-right'
+  return (
+    <div className={`flex flex-col gap-2.5 ${alignItems}`}>
+      {serving && (
+        <span
+          className={`inline-flex items-center gap-1.5 font-mono text-[11px] font-bold tracking-[0.14em] text-ball-500 ${flexDir}`}
+        >
+          <span
+            className="size-[9px] animate-ball-pulse rounded-full bg-ball-500"
+            style={{ boxShadow: '0 0 10px rgba(255,122,26,0.7)' }}
+          />
+          SERVING
+        </span>
+      )}
+      <div
+        className={`font-display uppercase tracking-[0.02em] text-chalk-50 ${textAlign}`}
+        style={{ fontSize: 54, lineHeight: 0.95 }}
+      >
+        {name.split(' ').map((w, i) => (
+          <div key={i}>{w}</div>
+        ))}
+      </div>
+      <div
+        className={`flex items-center gap-2.5 font-mono text-[12px] tracking-[0.08em] text-chalk-300 ${flexDir}`}
+      >
+        <span>[#{seed}]</span>
+        <span>·</span>
+        <span>{rating}</span>
+        {isLeft && (
+          <>
+            <span>·</span>
+            <span className="text-ball-500">YOU</span>
+          </>
+        )}
+      </div>
+      <div className={`flex gap-1.5 ${flexDir}`}>
+        {Array.from({ length: needed }).map((_, i) => {
+          const won = i < gamesWon
+          return (
+            <span
+              key={i}
+              className="size-3.5 rounded-full border-2"
+              style={{
+                background: won ? 'var(--color-ball-500)' : 'transparent',
+                borderColor: won
+                  ? 'var(--color-ball-500)'
+                  : 'var(--color-ink-500)',
+                boxShadow: won ? '0 0 8px rgba(255,122,26,0.5)' : 'none',
+              }}
+            />
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+type CenterScoreProps = {
+  myScore: number
+  theirScore: number
+  gameLabel: string
+}
+
+function CenterScore({ myScore, theirScore, gameLabel }: CenterScoreProps) {
+  return (
+    <div className="flex min-w-[320px] flex-col items-center gap-1">
+      <Overline
+        className="text-ball-500"
+        style={{ letterSpacing: '0.22em' }}
+      >
+        {gameLabel}
+      </Overline>
+      <div className="flex items-baseline gap-[18px] px-2.5 py-1.5">
+        <Mono size={132} color="var(--color-chalk-50)" weight={700}>
+          {myScore}
+        </Mono>
+        <span
+          className="font-display text-ink-400"
+          style={{ fontSize: 38 }}
+        >
+          —
+        </span>
+        <Mono size={132} color="var(--color-chalk-100)" weight={700}>
+          {theirScore}
+        </Mono>
+      </div>
+    </div>
+  )
+}
+
+function GameStrip({
+  games,
+  bestOf,
+}: {
+  games: GameScore[]
+  bestOf: number
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-2 rounded-md border border-ink-600 bg-ink-900 p-3.5">
+      <Overline className="mr-2 self-center">GAMES</Overline>
+      {games.map((g, i) => {
+        const active = g.winner === null
+        return (
+          <div
+            key={i}
+            className="flex min-w-[92px] items-center gap-2.5 rounded-sm border px-3 py-1.5"
+            style={{
+              background: active
+                ? 'rgba(255,122,26,0.09)'
+                : 'var(--color-ink-800)',
+              borderColor: active
+                ? 'rgba(255,122,26,0.35)'
+                : 'var(--color-ink-600)',
+            }}
+          >
+            <Mono size={10} color="var(--color-chalk-300)">
+              G{i + 1}
+            </Mono>
+            <Mono
+              size={15}
+              color={
+                g.winner === 'me'
+                  ? 'var(--color-serve-500)'
+                  : 'var(--color-chalk-50)'
+              }
+              weight={g.winner === 'me' ? 700 : 600}
+            >
+              {g.me}
+            </Mono>
+            <Mono size={11} color="var(--color-ink-400)">
+              –
+            </Mono>
+            <Mono
+              size={15}
+              color={
+                g.winner === 'them'
+                  ? 'var(--color-serve-500)'
+                  : 'var(--color-chalk-50)'
+              }
+              weight={g.winner === 'them' ? 700 : 600}
+            >
+              {g.them}
+            </Mono>
+          </div>
+        )
+      })}
+      {Array.from({ length: Math.max(0, bestOf - games.length) }).map(
+        (_, i) => (
+          <div
+            key={`f${i}`}
+            className="flex min-w-[92px] items-center justify-center rounded-sm border border-dashed border-ink-600 px-3 py-1.5"
+          >
+            <Mono size={11} color="var(--color-ink-400)">
+              G{games.length + i + 1}
+            </Mono>
+          </div>
+        ),
+      )}
+    </div>
+  )
+}
+
+function OpponentStrip({ match }: { match: LiveMatch }) {
+  const o = match.opponent
+  const firstName = o.name.split(' ')[0]
+  return (
+    <div className="mt-3.5 grid grid-cols-4 gap-2.5">
+      <MetaTile
+        label="Head to head"
+        value={`${o.h2h.w}–${o.h2h.l}`}
+        sub={`You lead vs ${firstName}`}
+      />
+      <MetaTile
+        label="Style"
+        value={o.style}
+        sub={`${o.hand} handed`}
+        mono={false}
+      />
+      <MetaTile
+        label="Opponent club"
+        value={o.club}
+        mono={false}
+        sub="3 visits this season"
+      />
+      <MetaTile
+        label="Rating gap"
+        value={`+${match.me.rating - o.rating}`}
+        sub="In your favour"
+        accent="var(--color-serve-500)"
+      />
+    </div>
+  )
+}
+
+type MetaTileProps = {
+  label: string
+  value: string
+  sub?: string
+  mono?: boolean
+  accent?: string
+}
+
+function MetaTile({
+  label,
+  value,
+  sub,
+  mono = true,
+  accent,
+}: MetaTileProps) {
+  return (
+    <div className="rounded-md border border-ink-600 bg-white/[0.015] px-3.5 py-3">
+      <Overline>{label}</Overline>
+      <div
+        className={
+          mono ? 'font-mono tabular-nums' : 'font-sans'
+        }
+        style={{
+          fontSize: mono ? 20 : 15,
+          color: accent ?? 'var(--color-chalk-50)',
+          marginTop: 4,
+          fontWeight: 600,
+          letterSpacing: mono ? '-0.01em' : '0',
+        }}
+      >
+        {value}
+      </div>
+      {sub && (
+        <div className="mt-0.5 text-[11px] text-chalk-300">{sub}</div>
+      )}
+    </div>
+  )
+}
+
+type HeroCardProps = {
+  match: LiveMatch
+  currentGame: GameScore
+  myGamesWon: number
+  theirGamesWon: number
+}
+
+function LiveMatchHeroCard({
+  match,
+  currentGame,
+  myGamesWon,
+  theirGamesWon,
+}: HeroCardProps) {
+  return (
+    <div
+      className="relative overflow-hidden rounded-lg border px-[22px] py-[18px]"
+      style={{
+        background: 'var(--color-ink-800)',
+        borderColor: 'rgba(0,226,154,0.35)',
+        boxShadow: '0 0 32px rgba(0,226,154,0.08)',
+      }}
+    >
+      <div className="mb-3 flex items-center justify-between">
+        <div className="flex items-center gap-2.5">
+          <Pill tone="live" icon={<LiveDot size={7} />}>
+            YOU'RE ON · COURT {match.court}
+          </Pill>
+          <Mono size={11} color="var(--color-chalk-300)">
+            {match.round} · G{match.games.length}
+          </Mono>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="ghost-secondary" size="sm">
+            <Maximize2 />
+            Expand
+          </Button>
+          <Button variant="primary" size="sm">
+            <Plus />
+            +1
+          </Button>
+        </div>
+      </div>
+      <div
+        className="grid items-center gap-5"
+        style={{ gridTemplateColumns: '1fr auto 1fr' }}
+      >
+        <div>
+          <div
+            className="font-display uppercase tracking-[0.02em] text-chalk-50"
+            style={{ fontSize: 32 }}
+          >
+            {match.me.name}
+          </div>
+          <Mono size={11} color="var(--color-chalk-300)">
+            [#{match.me.seed}] · {match.me.rating} · YOU
+          </Mono>
+        </div>
+        <div className="text-center">
+          <div className="flex items-baseline justify-center gap-2.5">
+            <Mono size={52} color="var(--color-chalk-50)" weight={700}>
+              {currentGame.me}
+            </Mono>
+            <Mono size={22} color="var(--color-ink-400)">
+              –
+            </Mono>
+            <Mono size={52} color="var(--color-chalk-100)" weight={700}>
+              {currentGame.them}
+            </Mono>
+          </div>
+          <Mono size={11} color="var(--color-chalk-300)">
+            games: {myGamesWon} – {theirGamesWon}
+          </Mono>
+        </div>
+        <div className="text-right">
+          <div
+            className="font-display uppercase tracking-[0.02em] text-chalk-50"
+            style={{ fontSize: 32 }}
+          >
+            {match.opponent.name}
+          </div>
+          <Mono size={11} color="var(--color-chalk-300)">
+            [#{match.opponent.seed}] · {match.opponent.rating}
+          </Mono>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/dashboard/live-match.tsx
+++ b/src/components/dashboard/live-match.tsx
@@ -9,6 +9,7 @@ import {
   X,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 import type { GameScore, LiveMatch } from './data'
 import { LiveDot, Mono, Overline, Pill } from './primitives'
 
@@ -77,7 +78,7 @@ export function LiveMatchScoreboard({
             <span>BEST OF {match.bestOf}</span>
           </div>
           <div className="flex-1" />
-          <Mono size={13} color="var(--color-chalk-300)">
+          <Mono size={13} className="text-chalk-300">
             ⌚ {match.timer} since {match.startedAt}
           </Mono>
           <Button variant="ghost-secondary" size="sm" onClick={onExit}>
@@ -127,14 +128,14 @@ export function LiveMatchScoreboard({
           <Button variant="primary" size="lg">
             <Plus />
             +1 for me
-            <Mono size={11} color="var(--color-ink-950)" className="ml-1">
+            <Mono size={11} className="ml-1 text-ink-950">
               SPACE
             </Mono>
           </Button>
           <Button variant="secondary" size="lg">
             <Plus />
             +1 for opponent
-            <Mono size={11} color="var(--color-chalk-300)" className="ml-1">
+            <Mono size={11} className="ml-1 text-chalk-300">
               N
             </Mono>
           </Button>
@@ -154,7 +155,7 @@ export function LiveMatchScoreboard({
           <Button
             variant="ghost-secondary"
             size="lg"
-            className="border-[rgba(255,77,109,0.4)] text-loss hover:bg-loss/10 hover:text-loss"
+            className="border-loss/40 text-loss hover:bg-loss/10 hover:text-loss"
           >
             <X />
             Retire
@@ -256,23 +257,15 @@ type CenterScoreProps = {
 function CenterScore({ myScore, theirScore, gameLabel }: CenterScoreProps) {
   return (
     <div className="flex min-w-[320px] flex-col items-center gap-1">
-      <Overline
-        className="text-ball-500"
-        style={{ letterSpacing: '0.22em' }}
-      >
+      <Overline className="tracking-[0.22em] text-ball-500">
         {gameLabel}
       </Overline>
       <div className="flex items-baseline gap-[18px] px-2.5 py-1.5">
-        <Mono size={132} color="var(--color-chalk-50)" weight={700}>
+        <Mono size={132} weight={700} className="text-chalk-50">
           {myScore}
         </Mono>
-        <span
-          className="font-display text-ink-400"
-          style={{ fontSize: 38 }}
-        >
-          —
-        </span>
-        <Mono size={132} color="var(--color-chalk-100)" weight={700}>
+        <span className="font-display text-[38px] text-ink-400">—</span>
+        <Mono size={132} weight={700} className="text-chalk-100">
           {theirScore}
         </Mono>
       </div>
@@ -295,44 +288,21 @@ function GameStrip({
         return (
           <div
             key={i}
-            className="flex min-w-[92px] items-center gap-2.5 rounded-sm border px-3 py-1.5"
-            style={{
-              background: active
-                ? 'rgba(255,122,26,0.09)'
-                : 'var(--color-ink-800)',
-              borderColor: active
-                ? 'rgba(255,122,26,0.35)'
-                : 'var(--color-ink-600)',
-            }}
+            className={cn(
+              'flex min-w-[92px] items-center gap-2.5 rounded-sm border px-3 py-1.5',
+              active
+                ? 'bg-ball-500/9 border-ball-500/35'
+                : 'bg-ink-800 border-ink-600',
+            )}
           >
-            <Mono size={10} color="var(--color-chalk-300)">
+            <Mono size={10} className="text-chalk-300">
               G{i + 1}
             </Mono>
-            <Mono
-              size={15}
-              color={
-                g.winner === 'me'
-                  ? 'var(--color-serve-500)'
-                  : 'var(--color-chalk-50)'
-              }
-              weight={g.winner === 'me' ? 700 : 600}
-            >
-              {g.me}
-            </Mono>
-            <Mono size={11} color="var(--color-ink-400)">
+            <GameScoreCell score={g.me} won={g.winner === 'me'} />
+            <Mono size={11} className="text-ink-400">
               –
             </Mono>
-            <Mono
-              size={15}
-              color={
-                g.winner === 'them'
-                  ? 'var(--color-serve-500)'
-                  : 'var(--color-chalk-50)'
-              }
-              weight={g.winner === 'them' ? 700 : 600}
-            >
-              {g.them}
-            </Mono>
+            <GameScoreCell score={g.them} won={g.winner === 'them'} />
           </div>
         )
       })}
@@ -342,13 +312,25 @@ function GameStrip({
             key={`f${i}`}
             className="flex min-w-[92px] items-center justify-center rounded-sm border border-dashed border-ink-600 px-3 py-1.5"
           >
-            <Mono size={11} color="var(--color-ink-400)">
+            <Mono size={11} className="text-ink-400">
               G{games.length + i + 1}
             </Mono>
           </div>
         ),
       )}
     </div>
+  )
+}
+
+function GameScoreCell({ score, won }: { score: number; won: boolean }) {
+  return (
+    <Mono
+      size={15}
+      weight={won ? 700 : 600}
+      className={won ? 'text-serve-500' : 'text-chalk-50'}
+    >
+      {score}
+    </Mono>
   )
 }
 
@@ -378,7 +360,7 @@ function OpponentStrip({ match }: { match: LiveMatch }) {
         label="Rating gap"
         value={`+${match.me.rating - o.rating}`}
         sub="In your favour"
-        accent="var(--color-serve-500)"
+        accent="text-serve-500"
       />
     </div>
   )
@@ -403,16 +385,13 @@ function MetaTile({
     <div className="rounded-md border border-ink-600 bg-white/[0.015] px-3.5 py-3">
       <Overline>{label}</Overline>
       <div
-        className={
-          mono ? 'font-mono tabular-nums' : 'font-sans'
-        }
-        style={{
-          fontSize: mono ? 20 : 15,
-          color: accent ?? 'var(--color-chalk-50)',
-          marginTop: 4,
-          fontWeight: 600,
-          letterSpacing: mono ? '-0.01em' : '0',
-        }}
+        className={cn(
+          'mt-1 font-semibold',
+          mono
+            ? 'font-mono text-[20px] tracking-[-0.01em] tabular-nums'
+            : 'font-sans text-[15px]',
+          accent ?? 'text-chalk-50',
+        )}
       >
         {value}
       </div>
@@ -437,20 +416,13 @@ function LiveMatchHeroCard({
   theirGamesWon,
 }: HeroCardProps) {
   return (
-    <div
-      className="relative overflow-hidden rounded-lg border px-[22px] py-[18px]"
-      style={{
-        background: 'var(--color-ink-800)',
-        borderColor: 'rgba(0,226,154,0.35)',
-        boxShadow: '0 0 32px rgba(0,226,154,0.08)',
-      }}
-    >
+    <div className="relative overflow-hidden rounded-lg border border-serve-500/35 bg-ink-800 px-[22px] py-[18px] shadow-[0_0_32px_rgba(0,226,154,0.08)]">
       <div className="mb-3 flex items-center justify-between">
         <div className="flex items-center gap-2.5">
           <Pill tone="live" icon={<LiveDot size={7} />}>
             YOU'RE ON · COURT {match.court}
           </Pill>
-          <Mono size={11} color="var(--color-chalk-300)">
+          <Mono size={11} className="text-chalk-300">
             {match.round} · G{match.games.length}
           </Mono>
         </div>
@@ -470,40 +442,34 @@ function LiveMatchHeroCard({
         style={{ gridTemplateColumns: '1fr auto 1fr' }}
       >
         <div>
-          <div
-            className="font-display uppercase tracking-[0.02em] text-chalk-50"
-            style={{ fontSize: 32 }}
-          >
+          <div className="font-display text-[32px] uppercase tracking-[0.02em] text-chalk-50">
             {match.me.name}
           </div>
-          <Mono size={11} color="var(--color-chalk-300)">
+          <Mono size={11} className="text-chalk-300">
             [#{match.me.seed}] · {match.me.rating} · YOU
           </Mono>
         </div>
         <div className="text-center">
           <div className="flex items-baseline justify-center gap-2.5">
-            <Mono size={52} color="var(--color-chalk-50)" weight={700}>
+            <Mono size={52} weight={700} className="text-chalk-50">
               {currentGame.me}
             </Mono>
-            <Mono size={22} color="var(--color-ink-400)">
+            <Mono size={22} className="text-ink-400">
               –
             </Mono>
-            <Mono size={52} color="var(--color-chalk-100)" weight={700}>
+            <Mono size={52} weight={700} className="text-chalk-100">
               {currentGame.them}
             </Mono>
           </div>
-          <Mono size={11} color="var(--color-chalk-300)">
+          <Mono size={11} className="text-chalk-300">
             games: {myGamesWon} – {theirGamesWon}
           </Mono>
         </div>
         <div className="text-right">
-          <div
-            className="font-display uppercase tracking-[0.02em] text-chalk-50"
-            style={{ fontSize: 32 }}
-          >
+          <div className="font-display text-[32px] uppercase tracking-[0.02em] text-chalk-50">
             {match.opponent.name}
           </div>
-          <Mono size={11} color="var(--color-chalk-300)">
+          <Mono size={11} className="text-chalk-300">
             [#{match.opponent.seed}] · {match.opponent.rating}
           </Mono>
         </div>

--- a/src/components/dashboard/primitives.tsx
+++ b/src/components/dashboard/primitives.tsx
@@ -57,45 +57,14 @@ type PillTone =
   | 'warn'
   | 'ghost'
 
-const PILL_TONES: Record<
-  PillTone,
-  { bg: string; fg: string; br: string }
-> = {
-  neutral: {
-    bg: 'var(--color-ink-800)',
-    fg: 'var(--color-chalk-100)',
-    br: 'var(--color-ink-600)',
-  },
-  live: {
-    bg: 'rgba(0,226,154,0.12)',
-    fg: 'var(--color-serve-500)',
-    br: 'rgba(0,226,154,0.35)',
-  },
-  ball: {
-    bg: 'rgba(255,122,26,0.12)',
-    fg: 'var(--color-ball-500)',
-    br: 'rgba(255,122,26,0.35)',
-  },
-  win: {
-    bg: 'rgba(0,226,154,0.12)',
-    fg: 'var(--color-serve-500)',
-    br: 'rgba(0,226,154,0.35)',
-  },
-  loss: {
-    bg: 'rgba(255,77,109,0.12)',
-    fg: 'var(--color-loss)',
-    br: 'rgba(255,77,109,0.35)',
-  },
-  warn: {
-    bg: 'rgba(255,196,61,0.12)',
-    fg: 'var(--color-warn)',
-    br: 'rgba(255,196,61,0.35)',
-  },
-  ghost: {
-    bg: 'transparent',
-    fg: 'var(--color-chalk-300)',
-    br: 'var(--color-ink-500)',
-  },
+const PILL_TONES: Record<PillTone, string> = {
+  neutral: 'bg-ink-800 text-chalk-100 border-ink-600',
+  live: 'bg-serve-500/12 text-serve-500 border-serve-500/35',
+  ball: 'bg-ball-500/12 text-ball-500 border-ball-500/35',
+  win: 'bg-serve-500/12 text-serve-500 border-serve-500/35',
+  loss: 'bg-loss/12 text-loss border-loss/35',
+  warn: 'bg-warn/12 text-warn border-warn/30',
+  ghost: 'bg-transparent text-chalk-300 border-ink-500',
 }
 
 type PillProps = {
@@ -111,18 +80,13 @@ export function Pill({
   icon,
   className,
 }: PillProps) {
-  const t = PILL_TONES[tone]
   return (
     <span
       className={cn(
         'inline-flex items-center gap-1.5 rounded-pill border px-2.5 py-1 font-mono text-[11px] font-semibold tracking-[0.12em] uppercase leading-none',
+        PILL_TONES[tone],
         className,
       )}
-      style={{
-        background: t.bg,
-        color: t.fg,
-        borderColor: t.br,
-      }}
     >
       {icon}
       {children}
@@ -195,7 +159,7 @@ export function Card({
       className={cn(
         'rounded-md border bg-ink-800',
         live
-          ? 'border-[rgba(0,226,154,0.35)] shadow-[0_0_32px_rgba(0,226,154,0.10)]'
+          ? 'border-serve-500/35 shadow-[0_0_32px_rgba(0,226,154,0.10)]'
           : 'border-ink-600',
         className,
       )}
@@ -242,18 +206,21 @@ type MonoProps = {
 export function Mono({
   children,
   size = 14,
-  color = 'var(--color-chalk-50)',
+  color,
   weight = 600,
   className,
   style,
 }: MonoProps) {
   return (
     <span
-      className={cn('font-mono tabular-nums tracking-[-0.01em]', className)}
+      className={cn(
+        'font-mono tabular-nums tracking-[-0.01em] text-chalk-50',
+        className,
+      )}
       style={{
         fontSize: size,
-        color,
         fontWeight: weight,
+        ...(color ? { color } : {}),
         ...style,
       }}
     >

--- a/src/components/dashboard/primitives.tsx
+++ b/src/components/dashboard/primitives.tsx
@@ -1,0 +1,306 @@
+import type { CSSProperties, ReactNode } from 'react'
+import { cn } from '@/lib/utils'
+
+type OverlineProps = {
+  children: ReactNode
+  className?: string
+  style?: CSSProperties
+}
+
+export function Overline({ children, className, style }: OverlineProps) {
+  return (
+    <div
+      className={cn(
+        'font-sans text-[10px] font-semibold tracking-[0.16em] text-chalk-300 uppercase',
+        className,
+      )}
+      style={style}
+    >
+      {children}
+    </div>
+  )
+}
+
+type LiveDotProps = {
+  color?: string
+  size?: number
+  className?: string
+}
+
+export function LiveDot({
+  color = 'var(--color-serve-500)',
+  size = 8,
+  className,
+}: LiveDotProps) {
+  return (
+    <span
+      className={cn(
+        'inline-block shrink-0 animate-ball-pulse rounded-full',
+        className,
+      )}
+      style={{
+        width: size,
+        height: size,
+        background: color,
+        boxShadow: `0 0 10px ${color}`,
+      }}
+    />
+  )
+}
+
+type PillTone =
+  | 'neutral'
+  | 'live'
+  | 'ball'
+  | 'win'
+  | 'loss'
+  | 'warn'
+  | 'ghost'
+
+const PILL_TONES: Record<
+  PillTone,
+  { bg: string; fg: string; br: string }
+> = {
+  neutral: {
+    bg: 'var(--color-ink-800)',
+    fg: 'var(--color-chalk-100)',
+    br: 'var(--color-ink-600)',
+  },
+  live: {
+    bg: 'rgba(0,226,154,0.12)',
+    fg: 'var(--color-serve-500)',
+    br: 'rgba(0,226,154,0.35)',
+  },
+  ball: {
+    bg: 'rgba(255,122,26,0.12)',
+    fg: 'var(--color-ball-500)',
+    br: 'rgba(255,122,26,0.35)',
+  },
+  win: {
+    bg: 'rgba(0,226,154,0.12)',
+    fg: 'var(--color-serve-500)',
+    br: 'rgba(0,226,154,0.35)',
+  },
+  loss: {
+    bg: 'rgba(255,77,109,0.12)',
+    fg: 'var(--color-loss)',
+    br: 'rgba(255,77,109,0.35)',
+  },
+  warn: {
+    bg: 'rgba(255,196,61,0.12)',
+    fg: 'var(--color-warn)',
+    br: 'rgba(255,196,61,0.35)',
+  },
+  ghost: {
+    bg: 'transparent',
+    fg: 'var(--color-chalk-300)',
+    br: 'var(--color-ink-500)',
+  },
+}
+
+type PillProps = {
+  children: ReactNode
+  tone?: PillTone
+  icon?: ReactNode
+  className?: string
+}
+
+export function Pill({
+  children,
+  tone = 'neutral',
+  icon,
+  className,
+}: PillProps) {
+  const t = PILL_TONES[tone]
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-pill border px-2.5 py-1 font-mono text-[11px] font-semibold tracking-[0.12em] uppercase leading-none',
+        className,
+      )}
+      style={{
+        background: t.bg,
+        color: t.fg,
+        borderColor: t.br,
+      }}
+    >
+      {icon}
+      {children}
+    </span>
+  )
+}
+
+type AvatarTone = 'ball' | 'serve' | 'ink' | 'muted'
+type AvatarProps = {
+  initials: string
+  size?: number
+  tone?: AvatarTone
+  className?: string
+}
+
+const AVATAR_TONES: Record<AvatarTone, { bg: string; fg: string }> = {
+  ball: {
+    bg: 'linear-gradient(135deg,#FFB57A,#FF7A1A 55%,#B94700)',
+    fg: '#111',
+  },
+  serve: {
+    bg: 'linear-gradient(135deg,#8CFFD4,#00E29A 55%,#009968)',
+    fg: '#111',
+  },
+  ink: { bg: 'var(--color-ink-700)', fg: 'var(--color-chalk-50)' },
+  muted: { bg: 'var(--color-ink-800)', fg: 'var(--color-chalk-100)' },
+}
+
+export function Avatar({
+  initials,
+  size = 40,
+  tone = 'ink',
+  className,
+}: AvatarProps) {
+  const t = AVATAR_TONES[tone]
+  return (
+    <div
+      className={cn(
+        'inline-flex shrink-0 items-center justify-center rounded-full border border-white/5 font-sans font-bold tracking-[0.02em]',
+        className,
+      )}
+      style={{
+        width: size,
+        height: size,
+        background: t.bg,
+        color: t.fg,
+        fontSize: size * 0.38,
+      }}
+    >
+      {initials}
+    </div>
+  )
+}
+
+type CardProps = {
+  children: ReactNode
+  className?: string
+  pad?: number
+  live?: boolean
+}
+
+export function Card({
+  children,
+  className,
+  pad = 0,
+  live = false,
+}: CardProps) {
+  return (
+    <div
+      className={cn(
+        'rounded-md border bg-ink-800',
+        live
+          ? 'border-[rgba(0,226,154,0.35)] shadow-[0_0_32px_rgba(0,226,154,0.10)]'
+          : 'border-ink-600',
+        className,
+      )}
+      style={pad ? { padding: pad } : undefined}
+    >
+      {children}
+    </div>
+  )
+}
+
+type SectionHeaderProps = {
+  eyebrow?: ReactNode
+  title: ReactNode
+  right?: ReactNode
+}
+
+export function SectionHeader({
+  eyebrow,
+  title,
+  right,
+}: SectionHeaderProps) {
+  return (
+    <div className="mb-3.5 flex items-end justify-between gap-4">
+      <div>
+        {eyebrow && <Overline className="mb-1.5">{eyebrow}</Overline>}
+        <div className="font-sans text-lg font-semibold tracking-[-0.01em] text-chalk-50">
+          {title}
+        </div>
+      </div>
+      {right}
+    </div>
+  )
+}
+
+type MonoProps = {
+  children: ReactNode
+  size?: number
+  color?: string
+  weight?: number
+  className?: string
+  style?: CSSProperties
+}
+
+export function Mono({
+  children,
+  size = 14,
+  color = 'var(--color-chalk-50)',
+  weight = 600,
+  className,
+  style,
+}: MonoProps) {
+  return (
+    <span
+      className={cn('font-mono tabular-nums tracking-[-0.01em]', className)}
+      style={{
+        fontSize: size,
+        color,
+        fontWeight: weight,
+        ...style,
+      }}
+    >
+      {children}
+    </span>
+  )
+}
+
+type MiniStatProps = {
+  label: string
+  value: string
+  accent?: string
+}
+
+export function MiniStat({ label, value, accent }: MiniStatProps) {
+  return (
+    <div className="rounded-sm border border-ink-600 bg-ink-900 px-3 py-2.5">
+      <Overline className="text-[9px]">{label}</Overline>
+      <Mono
+        size={18}
+        color={accent ?? 'var(--color-chalk-50)'}
+        weight={700}
+        className="mt-0.5 block"
+      >
+        {value}
+      </Mono>
+    </div>
+  )
+}
+
+type TextLinkProps = {
+  children: ReactNode
+  onClick?: () => void
+  className?: string
+}
+
+export function TextLink({ children, onClick, className }: TextLinkProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'cursor-pointer font-sans text-[12px] text-chalk-300 hover:text-chalk-50',
+        className,
+      )}
+    >
+      {children}
+    </button>
+  )
+}

--- a/src/components/dashboard/rating-panel.tsx
+++ b/src/components/dashboard/rating-panel.tsx
@@ -1,0 +1,111 @@
+import { useId } from 'react'
+import { ME } from './data'
+import { Card, MiniStat, Mono, Pill, SectionHeader } from './primitives'
+
+const POINTS = [
+  1720, 1735, 1742, 1738, 1755, 1780, 1804, 1822, 1830, 1842, 1824, 1847,
+] as const
+
+const SVG_W = 320
+const SVG_H = 88
+
+const SPARKLINE_PATH = (() => {
+  const min = Math.min(...POINTS) - 10
+  const max = Math.max(...POINTS) + 10
+  const norm = (v: number) => (v - min) / (max - min)
+  const body = POINTS.map((p, i) => {
+    const x = (i / (POINTS.length - 1)) * SVG_W
+    const y = SVG_H - norm(p) * SVG_H
+    return `${i === 0 ? 'M' : 'L'} ${x.toFixed(1)} ${y.toFixed(1)}`
+  }).join(' ')
+  const lastY = SVG_H - norm(POINTS[POINTS.length - 1]) * SVG_H
+  return { body, lastX: SVG_W, lastY }
+})()
+
+export function RatingPanel() {
+  const gradientId = useId()
+
+  return (
+    <Card pad={20}>
+      <SectionHeader
+        eyebrow="RATING"
+        title="Your rating"
+        right={<Pill tone="win">▲ +{ME.ratingDelta} this week</Pill>}
+      />
+      <div className="mb-3 flex items-end gap-[18px]">
+        <Mono size={54} weight={700}>
+          {ME.rating}
+        </Mono>
+        <div className="pb-2.5">
+          <Mono size={12} color="var(--color-chalk-300)">
+            peak <span className="text-chalk-50">1,870</span>
+          </Mono>
+          <div className="text-[12px] text-chalk-300">A / region top 12%</div>
+        </div>
+      </div>
+
+      <svg
+        width="100%"
+        viewBox={`0 0 ${SVG_W} ${SVG_H}`}
+        preserveAspectRatio="none"
+        className="block overflow-visible"
+      >
+        <defs>
+          <linearGradient id={gradientId} x1="0" x2="0" y1="0" y2="1">
+            <stop
+              offset="0%"
+              stopColor="var(--color-ball-500)"
+              stopOpacity="0.35"
+            />
+            <stop
+              offset="100%"
+              stopColor="var(--color-ball-500)"
+              stopOpacity="0"
+            />
+          </linearGradient>
+        </defs>
+        <path
+          d={`${SPARKLINE_PATH.body} L ${SVG_W} ${SVG_H} L 0 ${SVG_H} Z`}
+          fill={`url(#${gradientId})`}
+        />
+        <path
+          d={SPARKLINE_PATH.body}
+          stroke="var(--color-ball-500)"
+          strokeWidth={2}
+          fill="none"
+        />
+        <circle
+          cx={SPARKLINE_PATH.lastX}
+          cy={SPARKLINE_PATH.lastY}
+          r={4}
+          fill="var(--color-ball-500)"
+          stroke="var(--color-ink-950)"
+          strokeWidth={2}
+        />
+      </svg>
+
+      <div className="mt-2 flex justify-between">
+        <Mono size={10} color="var(--color-chalk-300)">
+          12 WEEKS AGO
+        </Mono>
+        <Mono size={10} color="var(--color-chalk-300)">
+          TODAY
+        </Mono>
+      </div>
+
+      <div className="mt-4 grid grid-cols-3 gap-2.5">
+        <MiniStat label="Record" value={`${ME.record.w}–${ME.record.l}`} />
+        <MiniStat
+          label="Club rank"
+          value={`#${ME.rank.club}`}
+          accent="var(--color-ball-500)"
+        />
+        <MiniStat
+          label="Streak"
+          value={`${ME.streak}W`}
+          accent="var(--color-serve-500)"
+        />
+      </div>
+    </Card>
+  )
+}

--- a/src/components/dashboard/rating-panel.tsx
+++ b/src/components/dashboard/rating-panel.tsx
@@ -37,7 +37,7 @@ export function RatingPanel() {
           {ME.rating}
         </Mono>
         <div className="pb-2.5">
-          <Mono size={12} color="var(--color-chalk-300)">
+          <Mono size={12} className="text-chalk-300">
             peak <span className="text-chalk-50">1,870</span>
           </Mono>
           <div className="text-[12px] text-chalk-300">A / region top 12%</div>
@@ -85,10 +85,10 @@ export function RatingPanel() {
       </svg>
 
       <div className="mt-2 flex justify-between">
-        <Mono size={10} color="var(--color-chalk-300)">
+        <Mono size={10} className="text-chalk-300">
           12 WEEKS AGO
         </Mono>
-        <Mono size={10} color="var(--color-chalk-300)">
+        <Mono size={10} className="text-chalk-300">
           TODAY
         </Mono>
       </div>

--- a/src/components/dashboard/recent-matches.tsx
+++ b/src/components/dashboard/recent-matches.tsx
@@ -1,0 +1,68 @@
+import { RECENT_MATCHES } from './data'
+import { Card, Mono, SectionHeader, TextLink } from './primitives'
+
+export function RecentMatches() {
+  return (
+    <Card>
+      <div className="px-5 pt-4.5 pb-3.5">
+        <SectionHeader
+          eyebrow="LAST 5 MATCHES"
+          title="Recent"
+          right={<TextLink>See all →</TextLink>}
+        />
+      </div>
+      <div>
+        {RECENT_MATCHES.map((m, i) => (
+          <div
+            key={i}
+            className="grid cursor-pointer items-center gap-3.5 border-t border-ink-600 px-5 py-3 transition-colors hover:bg-white/[0.04]"
+            style={{
+              gridTemplateColumns: '90px 1fr auto auto 70px',
+            }}
+          >
+            <Mono size={11} color="var(--color-chalk-300)">
+              {m.when.toUpperCase()}
+            </Mono>
+            <div>
+              <div className="text-[14px] font-medium text-chalk-50">
+                vs {m.opponent}
+              </div>
+              <div className="text-[12px] text-chalk-300">{m.event}</div>
+            </div>
+            <div
+              className="flex size-6.5 items-center justify-center rounded-xs font-mono text-[13px] font-bold"
+              style={{
+                background:
+                  m.result === 'W'
+                    ? 'rgba(0,226,154,0.15)'
+                    : 'rgba(255,77,109,0.12)',
+                color:
+                  m.result === 'W'
+                    ? 'var(--color-serve-500)'
+                    : 'var(--color-loss)',
+              }}
+            >
+              {m.result}
+            </div>
+            <Mono size={14} color="var(--color-chalk-50)">
+              {m.score}
+            </Mono>
+            <Mono
+              size={13}
+              color={
+                m.delta > 0
+                  ? 'var(--color-serve-500)'
+                  : 'var(--color-loss)'
+              }
+              weight={700}
+              className="text-right"
+            >
+              {m.delta > 0 ? '+' : ''}
+              {m.delta}
+            </Mono>
+          </div>
+        ))}
+      </div>
+    </Card>
+  )
+}

--- a/src/components/dashboard/recent-matches.tsx
+++ b/src/components/dashboard/recent-matches.tsx
@@ -1,3 +1,4 @@
+import { cn } from '@/lib/utils'
 import { RECENT_MATCHES } from './data'
 import { Card, Mono, SectionHeader, TextLink } from './primitives'
 
@@ -12,56 +13,50 @@ export function RecentMatches() {
         />
       </div>
       <div>
-        {RECENT_MATCHES.map((m, i) => (
-          <div
-            key={i}
-            className="grid cursor-pointer items-center gap-3.5 border-t border-ink-600 px-5 py-3 transition-colors hover:bg-white/[0.04]"
-            style={{
-              gridTemplateColumns: '90px 1fr auto auto 70px',
-            }}
-          >
-            <Mono size={11} color="var(--color-chalk-300)">
-              {m.when.toUpperCase()}
-            </Mono>
-            <div>
-              <div className="text-[14px] font-medium text-chalk-50">
-                vs {m.opponent}
-              </div>
-              <div className="text-[12px] text-chalk-300">{m.event}</div>
-            </div>
+        {RECENT_MATCHES.map((m, i) => {
+          const isWin = m.result === 'W'
+          return (
             <div
-              className="flex size-6.5 items-center justify-center rounded-xs font-mono text-[13px] font-bold"
-              style={{
-                background:
-                  m.result === 'W'
-                    ? 'rgba(0,226,154,0.15)'
-                    : 'rgba(255,77,109,0.12)',
-                color:
-                  m.result === 'W'
-                    ? 'var(--color-serve-500)'
-                    : 'var(--color-loss)',
-              }}
+              key={i}
+              className="grid cursor-pointer items-center gap-3.5 border-t border-ink-600 px-5 py-3 transition-colors hover:bg-white/5"
+              style={{ gridTemplateColumns: '90px 1fr auto auto 70px' }}
             >
-              {m.result}
+              <Mono size={11} className="text-chalk-300">
+                {m.when.toUpperCase()}
+              </Mono>
+              <div>
+                <div className="text-[14px] font-medium text-chalk-50">
+                  vs {m.opponent}
+                </div>
+                <div className="text-[12px] text-chalk-300">{m.event}</div>
+              </div>
+              <div
+                className={cn(
+                  'flex size-6.5 items-center justify-center rounded-xs font-mono text-[13px] font-bold',
+                  isWin
+                    ? 'bg-serve-500/15 text-serve-500'
+                    : 'bg-loss/12 text-loss',
+                )}
+              >
+                {m.result}
+              </div>
+              <Mono size={14} className="text-chalk-50">
+                {m.score}
+              </Mono>
+              <Mono
+                size={13}
+                weight={700}
+                className={cn(
+                  'text-right',
+                  m.delta > 0 ? 'text-serve-500' : 'text-loss',
+                )}
+              >
+                {m.delta > 0 ? '+' : ''}
+                {m.delta}
+              </Mono>
             </div>
-            <Mono size={14} color="var(--color-chalk-50)">
-              {m.score}
-            </Mono>
-            <Mono
-              size={13}
-              color={
-                m.delta > 0
-                  ? 'var(--color-serve-500)'
-                  : 'var(--color-loss)'
-              }
-              weight={700}
-              className="text-right"
-            >
-              {m.delta > 0 ? '+' : ''}
-              {m.delta}
-            </Mono>
-          </div>
-        ))}
+          )
+        })}
       </div>
     </Card>
   )

--- a/src/components/dashboard/td-panel.tsx
+++ b/src/components/dashboard/td-panel.tsx
@@ -1,0 +1,297 @@
+import type { LucideIcon } from 'lucide-react'
+import {
+  ExternalLink,
+  Megaphone,
+  PencilLine,
+  RadioTower,
+  UserX,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import type { CourtStatus, NeedsYouKind, TDEvent } from './data'
+import { TD_EVENT } from './data'
+import { Card, LiveDot, Mono, Overline, TextLink } from './primitives'
+
+export function TDPanel() {
+  const t: TDEvent = TD_EVENT
+  return (
+    <Card>
+      <div className="flex items-center gap-3.5 border-b border-ink-600 px-[22px] py-[18px] pb-4">
+        <div className="flex size-11 shrink-0 items-center justify-center rounded-md border border-ball-500 bg-ink-950">
+          <RadioTower size={20} className="text-ball-500" />
+        </div>
+        <div className="flex-1">
+          <Overline className="mb-1">
+            DIRECTOR CONTROL · {t.name.toUpperCase()}
+          </Overline>
+          <div className="font-sans text-[20px] font-bold text-chalk-50">
+            Event is healthy
+          </div>
+          <div className="mt-0.5 font-mono text-[11px] tracking-[0.08em] text-chalk-300">
+            ON TIME · DRIFT {t.schedule.drift} · SOLVER{' '}
+            {t.solver.status.toUpperCase()}
+          </div>
+        </div>
+        <Button variant="secondary">
+          <ExternalLink />
+          Open control room
+        </Button>
+      </div>
+
+      <div className="grid grid-cols-5 border-b border-ink-600">
+        <TDStat
+          label="Courts live"
+          value={`${t.courts.live}/${t.courts.total}`}
+          sub={`${t.courts.open} open · ${t.courts.setup} setup`}
+        />
+        <TDStat
+          label="Matches done"
+          value={String(t.matches.done)}
+          sub={`${t.matches.live} live · ${t.matches.upcoming} ahead`}
+        />
+        <TDStat
+          label="Check-in"
+          value={`${t.players.checkedIn}/${t.players.total}`}
+          sub={`${t.players.noShow} no-show`}
+          accent={t.players.noShow ? 'var(--color-warn)' : undefined}
+        />
+        <TDStat
+          label="Unscored"
+          value={String(t.matches.unscored)}
+          sub="needs your attention"
+          accent={
+            t.matches.unscored ? 'var(--color-warn)' : 'var(--color-serve-500)'
+          }
+        />
+        <TDStat
+          label="Solver"
+          value={`${t.solver.ms}ms`}
+          sub={`${t.solver.conflicts} conflicts · optimal`}
+          accent="var(--color-serve-500)"
+        />
+      </div>
+
+      <div
+        className="grid"
+        style={{ gridTemplateColumns: '1fr 1.35fr' }}
+      >
+        <div className="border-r border-ink-600 px-[22px] py-[18px]">
+          <Overline className="mb-3">NEEDS YOU · 3 ITEMS</Overline>
+          <div className="flex flex-col gap-2.5">
+            {t.needsYou.map((n, i) => (
+              <NeedsYouRow key={i} n={n} />
+            ))}
+          </div>
+        </div>
+
+        <div className="px-[22px] py-[18px]">
+          <div className="mb-3 flex items-end justify-between">
+            <Overline>COURTS AT A GLANCE</Overline>
+            <TextLink>Open courts view →</TextLink>
+          </div>
+          <div className="grid grid-cols-4 gap-2">
+            {t.courtStatus.map((c) => (
+              <TDCourtTile key={c.n} c={c} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </Card>
+  )
+}
+
+type TDStatProps = {
+  label: string
+  value: string
+  sub: string
+  accent?: string
+}
+
+function TDStat({ label, value, sub, accent }: TDStatProps) {
+  return (
+    <div className="border-r border-ink-600 px-5 py-4 last:border-r-0">
+      <Overline className="mb-2 text-[10px]">{label}</Overline>
+      <Mono size={26} color={accent ?? 'var(--color-chalk-50)'} weight={700}>
+        {value}
+      </Mono>
+      <div className="mt-0.5 text-[11px] text-chalk-300">{sub}</div>
+    </div>
+  )
+}
+
+type NeedsYouItem = TDEvent['needsYou'][number]
+
+const NEEDS_YOU_ICON: Record<NeedsYouKind, LucideIcon> = {
+  score: PencilLine,
+  call: Megaphone,
+  nudge: UserX,
+}
+
+const NEEDS_YOU_CTA: Record<NeedsYouKind, string> = {
+  score: 'Score',
+  call: 'Call',
+  nudge: 'Nudge',
+}
+
+function NeedsYouRow({ n }: { n: NeedsYouItem }) {
+  const Icon = NEEDS_YOU_ICON[n.kind]
+  const tone = n.urgent
+    ? {
+        fg: 'var(--color-warn)',
+        bg: 'rgba(255,196,61,0.08)',
+        br: 'rgba(255,196,61,0.3)',
+        iconBg: 'rgba(255,196,61,0.18)',
+      }
+    : {
+        fg: 'var(--color-chalk-300)',
+        bg: 'var(--color-ink-900)',
+        br: 'var(--color-ink-600)',
+        iconBg: 'var(--color-ink-800)',
+      }
+  return (
+    <div
+      className="flex items-center gap-3 rounded-sm border px-3 py-2.5"
+      style={{ background: tone.bg, borderColor: tone.br }}
+    >
+      <div
+        className="flex size-[30px] shrink-0 items-center justify-center rounded-sm"
+        style={{ background: tone.iconBg, color: tone.fg }}
+      >
+        <Icon size={14} />
+      </div>
+      <div className="flex-1">
+        <div className="text-[13px] font-medium text-chalk-50">{n.label}</div>
+        <Mono size={10} color="var(--color-chalk-300)">
+          {n.detail.toUpperCase()}
+        </Mono>
+      </div>
+      <Button variant={n.urgent ? 'primary' : 'ghost-secondary'} size="sm">
+        {NEEDS_YOU_CTA[n.kind]}
+      </Button>
+    </div>
+  )
+}
+
+function TDCourtTile({ c }: { c: CourtStatus }) {
+  if (c.state === 'live') {
+    return (
+      <div
+        className="rounded-sm border p-2.5"
+        style={{
+          background: c.you ? 'rgba(255,122,26,0.08)' : 'var(--color-ink-900)',
+          borderColor: c.you
+            ? 'rgba(255,122,26,0.35)'
+            : 'rgba(0,226,154,0.25)',
+          boxShadow: c.you
+            ? '0 0 16px rgba(255,122,26,0.1)'
+            : '0 0 14px rgba(0,226,154,0.06)',
+        }}
+      >
+        <div className="mb-1.5 flex items-center justify-between">
+          <Mono
+            size={11}
+            color={
+              c.you ? 'var(--color-ball-500)' : 'var(--color-chalk-100)'
+            }
+            weight={700}
+          >
+            CT {c.n}
+            {c.you ? ' · YOU' : ''}
+          </Mono>
+          <LiveDot
+            color={
+              c.you
+                ? 'var(--color-ball-500)'
+                : 'var(--color-serve-500)'
+            }
+            size={6}
+          />
+        </div>
+        <div
+          className="flex items-center justify-between text-[12px]"
+          style={{
+            color:
+              c.win === 'a'
+                ? 'var(--color-serve-500)'
+                : 'var(--color-chalk-100)',
+          }}
+        >
+          <span>{c.a}</span>
+          <Mono
+            size={12}
+            color={
+              c.win === 'a'
+                ? 'var(--color-serve-500)'
+                : 'var(--color-chalk-50)'
+            }
+            weight={700}
+          >
+            {c.sa}
+          </Mono>
+        </div>
+        <div
+          className="mt-0.5 flex items-center justify-between text-[12px]"
+          style={{
+            color:
+              c.win === 'b'
+                ? 'var(--color-serve-500)'
+                : 'var(--color-chalk-100)',
+          }}
+        >
+          <span>{c.b}</span>
+          <Mono
+            size={12}
+            color={
+              c.win === 'b'
+                ? 'var(--color-serve-500)'
+                : 'var(--color-chalk-50)'
+            }
+            weight={700}
+          >
+            {c.sb}
+          </Mono>
+        </div>
+        <Mono size={9} color="var(--color-chalk-300)" className="mt-1.5 block">
+          GAME {c.g}
+        </Mono>
+      </div>
+    )
+  }
+  if (c.state === 'open') {
+    return (
+      <div className="flex min-h-[92px] flex-col justify-between rounded-sm border border-dashed border-ink-500 p-2.5">
+        <div className="flex justify-between">
+          <Mono size={11} color="var(--color-chalk-300)">
+            CT {c.n}
+          </Mono>
+          <Mono size={9} color="var(--color-serve-500)" weight={700}>
+            OPEN
+          </Mono>
+        </div>
+        <div className="text-[11px] text-chalk-300">
+          Next: <span className="text-chalk-50">{c.next}</span>
+        </div>
+        <button
+          type="button"
+          className="cursor-pointer self-start rounded-sm border border-ball-500 bg-transparent px-2 py-1 font-sans text-[11px] font-semibold text-ball-500 hover:bg-ball-500/10"
+        >
+          Call to court
+        </button>
+      </div>
+    )
+  }
+  return (
+    <div className="flex min-h-[92px] flex-col rounded-sm border border-ink-600 bg-white/[0.01] p-2.5">
+      <div className="flex justify-between">
+        <Mono size={11} color="var(--color-ink-400)">
+          CT {c.n}
+        </Mono>
+        <Mono size={9} color="var(--color-ink-400)" weight={700}>
+          SETUP
+        </Mono>
+      </div>
+      <div className="flex flex-1 items-center justify-center text-[11px] text-ink-400">
+        —
+      </div>
+    </div>
+  )
+}

--- a/src/components/dashboard/td-panel.tsx
+++ b/src/components/dashboard/td-panel.tsx
@@ -7,6 +7,7 @@ import {
   UserX,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 import type { CourtStatus, NeedsYouKind, TDEvent } from './data'
 import { TD_EVENT } from './data'
 import { Card, LiveDot, Mono, Overline, TextLink } from './primitives'
@@ -52,21 +53,19 @@ export function TDPanel() {
           label="Check-in"
           value={`${t.players.checkedIn}/${t.players.total}`}
           sub={`${t.players.noShow} no-show`}
-          accent={t.players.noShow ? 'var(--color-warn)' : undefined}
+          accent={t.players.noShow ? 'text-warn' : undefined}
         />
         <TDStat
           label="Unscored"
           value={String(t.matches.unscored)}
           sub="needs your attention"
-          accent={
-            t.matches.unscored ? 'var(--color-warn)' : 'var(--color-serve-500)'
-          }
+          accent={t.matches.unscored ? 'text-warn' : 'text-serve-500'}
         />
         <TDStat
           label="Solver"
           value={`${t.solver.ms}ms`}
           sub={`${t.solver.conflicts} conflicts · optimal`}
-          accent="var(--color-serve-500)"
+          accent="text-serve-500"
         />
       </div>
 
@@ -110,7 +109,7 @@ function TDStat({ label, value, sub, accent }: TDStatProps) {
   return (
     <div className="border-r border-ink-600 px-5 py-4 last:border-r-0">
       <Overline className="mb-2 text-[10px]">{label}</Overline>
-      <Mono size={26} color={accent ?? 'var(--color-chalk-50)'} weight={700}>
+      <Mono size={26} weight={700} className={accent ?? 'text-chalk-50'}>
         {value}
       </Mono>
       <div className="mt-0.5 text-[11px] text-chalk-300">{sub}</div>
@@ -132,35 +131,38 @@ const NEEDS_YOU_CTA: Record<NeedsYouKind, string> = {
   nudge: 'Nudge',
 }
 
+const NEEDS_YOU_TONE = {
+  urgent: {
+    container: 'bg-warn/8 border-warn/30',
+    iconBox: 'bg-warn/18 text-warn',
+  },
+  calm: {
+    container: 'bg-ink-900 border-ink-600',
+    iconBox: 'bg-ink-800 text-chalk-300',
+  },
+} as const
+
 function NeedsYouRow({ n }: { n: NeedsYouItem }) {
   const Icon = NEEDS_YOU_ICON[n.kind]
-  const tone = n.urgent
-    ? {
-        fg: 'var(--color-warn)',
-        bg: 'rgba(255,196,61,0.08)',
-        br: 'rgba(255,196,61,0.3)',
-        iconBg: 'rgba(255,196,61,0.18)',
-      }
-    : {
-        fg: 'var(--color-chalk-300)',
-        bg: 'var(--color-ink-900)',
-        br: 'var(--color-ink-600)',
-        iconBg: 'var(--color-ink-800)',
-      }
+  const tone = n.urgent ? NEEDS_YOU_TONE.urgent : NEEDS_YOU_TONE.calm
   return (
     <div
-      className="flex items-center gap-3 rounded-sm border px-3 py-2.5"
-      style={{ background: tone.bg, borderColor: tone.br }}
+      className={cn(
+        'flex items-center gap-3 rounded-sm border px-3 py-2.5',
+        tone.container,
+      )}
     >
       <div
-        className="flex size-[30px] shrink-0 items-center justify-center rounded-sm"
-        style={{ background: tone.iconBg, color: tone.fg }}
+        className={cn(
+          'flex size-[30px] shrink-0 items-center justify-center rounded-sm',
+          tone.iconBox,
+        )}
       >
         <Icon size={14} />
       </div>
       <div className="flex-1">
         <div className="text-[13px] font-medium text-chalk-50">{n.label}</div>
-        <Mono size={10} color="var(--color-chalk-300)">
+        <Mono size={10} className="text-chalk-300">
           {n.detail.toUpperCase()}
         </Mono>
       </div>
@@ -173,84 +175,39 @@ function NeedsYouRow({ n }: { n: NeedsYouItem }) {
 
 function TDCourtTile({ c }: { c: CourtStatus }) {
   if (c.state === 'live') {
+    const containerTone = c.you
+      ? 'bg-ball-500/8 border-ball-500/35 shadow-[0_0_16px_rgba(255,122,26,0.10)]'
+      : 'bg-ink-900 border-serve-500/25 shadow-[0_0_14px_rgba(0,226,154,0.06)]'
     return (
-      <div
-        className="rounded-sm border p-2.5"
-        style={{
-          background: c.you ? 'rgba(255,122,26,0.08)' : 'var(--color-ink-900)',
-          borderColor: c.you
-            ? 'rgba(255,122,26,0.35)'
-            : 'rgba(0,226,154,0.25)',
-          boxShadow: c.you
-            ? '0 0 16px rgba(255,122,26,0.1)'
-            : '0 0 14px rgba(0,226,154,0.06)',
-        }}
-      >
+      <div className={cn('rounded-sm border p-2.5', containerTone)}>
         <div className="mb-1.5 flex items-center justify-between">
           <Mono
             size={11}
-            color={
-              c.you ? 'var(--color-ball-500)' : 'var(--color-chalk-100)'
-            }
             weight={700}
+            className={c.you ? 'text-ball-500' : 'text-chalk-100'}
           >
             CT {c.n}
             {c.you ? ' · YOU' : ''}
           </Mono>
           <LiveDot
             color={
-              c.you
-                ? 'var(--color-ball-500)'
-                : 'var(--color-serve-500)'
+              c.you ? 'var(--color-ball-500)' : 'var(--color-serve-500)'
             }
             size={6}
           />
         </div>
-        <div
-          className="flex items-center justify-between text-[12px]"
-          style={{
-            color:
-              c.win === 'a'
-                ? 'var(--color-serve-500)'
-                : 'var(--color-chalk-100)',
-          }}
-        >
-          <span>{c.a}</span>
-          <Mono
-            size={12}
-            color={
-              c.win === 'a'
-                ? 'var(--color-serve-500)'
-                : 'var(--color-chalk-50)'
-            }
-            weight={700}
-          >
-            {c.sa}
-          </Mono>
-        </div>
-        <div
-          className="mt-0.5 flex items-center justify-between text-[12px]"
-          style={{
-            color:
-              c.win === 'b'
-                ? 'var(--color-serve-500)'
-                : 'var(--color-chalk-100)',
-          }}
-        >
-          <span>{c.b}</span>
-          <Mono
-            size={12}
-            color={
-              c.win === 'b'
-                ? 'var(--color-serve-500)'
-                : 'var(--color-chalk-50)'
-            }
-            weight={700}
-          >
-            {c.sb}
-          </Mono>
-        </div>
-        <Mono size={9} color="var(--color-chalk-300)" className="mt-1.5 block">
+        <CourtScoreRow
+          name={c.a}
+          score={c.sa}
+          won={c.win === 'a'}
+        />
+        <CourtScoreRow
+          name={c.b}
+          score={c.sb}
+          won={c.win === 'b'}
+          className="mt-0.5"
+        />
+        <Mono size={9} className="mt-1.5 block text-chalk-300">
           GAME {c.g}
         </Mono>
       </div>
@@ -260,10 +217,10 @@ function TDCourtTile({ c }: { c: CourtStatus }) {
     return (
       <div className="flex min-h-[92px] flex-col justify-between rounded-sm border border-dashed border-ink-500 p-2.5">
         <div className="flex justify-between">
-          <Mono size={11} color="var(--color-chalk-300)">
+          <Mono size={11} className="text-chalk-300">
             CT {c.n}
           </Mono>
-          <Mono size={9} color="var(--color-serve-500)" weight={700}>
+          <Mono size={9} weight={700} className="text-serve-500">
             OPEN
           </Mono>
         </div>
@@ -272,7 +229,7 @@ function TDCourtTile({ c }: { c: CourtStatus }) {
         </div>
         <button
           type="button"
-          className="cursor-pointer self-start rounded-sm border border-ball-500 bg-transparent px-2 py-1 font-sans text-[11px] font-semibold text-ball-500 hover:bg-ball-500/10"
+          className="self-start rounded-sm border border-ball-500 bg-transparent px-2 py-1 font-sans text-[11px] font-semibold text-ball-500 hover:bg-ball-500/10"
         >
           Call to court
         </button>
@@ -282,16 +239,44 @@ function TDCourtTile({ c }: { c: CourtStatus }) {
   return (
     <div className="flex min-h-[92px] flex-col rounded-sm border border-ink-600 bg-white/[0.01] p-2.5">
       <div className="flex justify-between">
-        <Mono size={11} color="var(--color-ink-400)">
+        <Mono size={11} className="text-ink-400">
           CT {c.n}
         </Mono>
-        <Mono size={9} color="var(--color-ink-400)" weight={700}>
+        <Mono size={9} weight={700} className="text-ink-400">
           SETUP
         </Mono>
       </div>
       <div className="flex flex-1 items-center justify-center text-[11px] text-ink-400">
         —
       </div>
+    </div>
+  )
+}
+
+type CourtScoreRowProps = {
+  name: string
+  score: number
+  won: boolean
+  className?: string
+}
+
+function CourtScoreRow({ name, score, won, className }: CourtScoreRowProps) {
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-between text-[12px]',
+        won ? 'text-serve-500' : 'text-chalk-100',
+        className,
+      )}
+    >
+      <span>{name}</span>
+      <Mono
+        size={12}
+        weight={700}
+        className={won ? 'text-serve-500' : 'text-chalk-50'}
+      >
+        {score}
+      </Mono>
     </div>
   )
 }

--- a/src/components/dashboard/topbar.tsx
+++ b/src/components/dashboard/topbar.tsx
@@ -1,3 +1,4 @@
+import { Link } from '@tanstack/react-router'
 import { Bell, Search, Zap } from 'lucide-react'
 import { Separator } from '@/components/ui/separator'
 import { cn } from '@/lib/utils'
@@ -6,13 +7,19 @@ import { ME, STATE_LABELS } from './data'
 import { Ball } from './ball'
 import { Avatar } from './primitives'
 
-const NAV_ITEMS: { label: string; active: boolean }[] = [
-  { label: 'Dashboard', active: true },
-  { label: 'Matches', active: false },
-  { label: 'Tournaments', active: false },
-  { label: 'Clubs', active: false },
-  { label: 'Find opponents', active: false },
+const NAV_ITEMS: { label: string; to?: '/dashboard' }[] = [
+  { label: 'Dashboard', to: '/dashboard' },
+  { label: 'Matches' },
+  { label: 'Tournaments' },
+  { label: 'Clubs' },
+  { label: 'Find opponents' },
 ]
+
+const NAV_ITEM_BASE = 'rounded-md px-3 py-2 transition-colors font-medium'
+const NAV_ITEM_ACTIVE = 'bg-white/5 font-semibold text-chalk-50'
+const NAV_ITEM_INACTIVE = 'text-chalk-300 hover:text-chalk-50'
+const NAV_ITEM_DISABLED =
+  'text-chalk-500 cursor-not-allowed hover:text-chalk-500'
 
 type TopBarProps = {
   state: DashboardState
@@ -31,19 +38,28 @@ export function TopBar({ state, onCycleState }: TopBarProps) {
       </div>
 
       <nav className="ml-6 flex gap-1 font-sans text-[13px]">
-        {NAV_ITEMS.map(({ label, active }) => (
-          <a
-            key={label}
-            className={cn(
-              'cursor-pointer rounded-md px-3 py-2 transition-colors',
-              active
-                ? 'bg-white/5 font-semibold text-chalk-50'
-                : 'font-medium text-chalk-300 hover:text-chalk-50',
-            )}
-          >
-            {label}
-          </a>
-        ))}
+        {NAV_ITEMS.map(({ label, to }) =>
+          to ? (
+            <Link
+              key={label}
+              to={to}
+              className={cn(NAV_ITEM_BASE, NAV_ITEM_INACTIVE)}
+              activeProps={{ className: cn(NAV_ITEM_BASE, NAV_ITEM_ACTIVE) }}
+            >
+              {label}
+            </Link>
+          ) : (
+            <button
+              key={label}
+              type="button"
+              aria-disabled
+              title="Coming soon"
+              className={cn(NAV_ITEM_BASE, NAV_ITEM_DISABLED)}
+            >
+              {label}
+            </button>
+          ),
+        )}
       </nav>
 
       <div className="flex-1" />
@@ -53,7 +69,7 @@ export function TopBar({ state, onCycleState }: TopBarProps) {
         onClick={onCycleState}
         aria-label={`Cycle dashboard state (current: ${s.label})`}
         title="Click to cycle states"
-        className="inline-flex cursor-pointer items-center gap-2.5 rounded-pill border border-ink-500 bg-ink-900 px-3 py-1.5 pl-2.5"
+        className="inline-flex items-center gap-2.5 rounded-pill border border-ink-500 bg-ink-900 py-1.5 pr-3 pl-2.5"
       >
         <Zap size={13} className="text-chalk-300" />
         <span className="font-mono text-[11px] tracking-[0.1em]">
@@ -69,14 +85,14 @@ export function TopBar({ state, onCycleState }: TopBarProps) {
       <button
         type="button"
         aria-label="Search"
-        className="cursor-pointer text-chalk-300 hover:text-chalk-50"
+        className="text-chalk-300 hover:text-chalk-50"
       >
         <Search size={18} />
       </button>
       <button
         type="button"
         aria-label="Notifications"
-        className="cursor-pointer text-chalk-300 hover:text-chalk-50"
+        className="text-chalk-300 hover:text-chalk-50"
       >
         <Bell size={18} />
       </button>

--- a/src/components/dashboard/topbar.tsx
+++ b/src/components/dashboard/topbar.tsx
@@ -1,0 +1,97 @@
+import { Bell, Search, Zap } from 'lucide-react'
+import { Separator } from '@/components/ui/separator'
+import { cn } from '@/lib/utils'
+import type { DashboardState } from './data'
+import { ME, STATE_LABELS } from './data'
+import { Ball } from './ball'
+import { Avatar } from './primitives'
+
+const NAV_ITEMS: { label: string; active: boolean }[] = [
+  { label: 'Dashboard', active: true },
+  { label: 'Matches', active: false },
+  { label: 'Tournaments', active: false },
+  { label: 'Clubs', active: false },
+  { label: 'Find opponents', active: false },
+]
+
+type TopBarProps = {
+  state: DashboardState
+  onCycleState: () => void
+}
+
+export function TopBar({ state, onCycleState }: TopBarProps) {
+  const s = STATE_LABELS[state]
+  return (
+    <header className="sticky top-0 z-40 flex h-16 items-center gap-5 border-b border-ink-600 bg-ink-950/75 px-10 backdrop-blur-xl">
+      <div className="flex items-center gap-3">
+        <Ball size={30} />
+        <span className="font-display text-2xl tracking-[0.04em] text-chalk-50">
+          FORTYMM<span className="text-ball-500">.</span>
+        </span>
+      </div>
+
+      <nav className="ml-6 flex gap-1 font-sans text-[13px]">
+        {NAV_ITEMS.map(({ label, active }) => (
+          <a
+            key={label}
+            className={cn(
+              'cursor-pointer rounded-md px-3 py-2 transition-colors',
+              active
+                ? 'bg-white/5 font-semibold text-chalk-50'
+                : 'font-medium text-chalk-300 hover:text-chalk-50',
+            )}
+          >
+            {label}
+          </a>
+        ))}
+      </nav>
+
+      <div className="flex-1" />
+
+      <button
+        type="button"
+        onClick={onCycleState}
+        aria-label={`Cycle dashboard state (current: ${s.label})`}
+        title="Click to cycle states"
+        className="inline-flex cursor-pointer items-center gap-2.5 rounded-pill border border-ink-500 bg-ink-900 px-3 py-1.5 pl-2.5"
+      >
+        <Zap size={13} className="text-chalk-300" />
+        <span className="font-mono text-[11px] tracking-[0.1em]">
+          <span className="text-chalk-300">STATE · </span>
+          <span className="font-bold text-ball-500">
+            {s.label.toUpperCase()}
+          </span>
+        </span>
+      </button>
+
+      <Separator orientation="vertical" className="!h-6 bg-ink-600" />
+
+      <button
+        type="button"
+        aria-label="Search"
+        className="cursor-pointer text-chalk-300 hover:text-chalk-50"
+      >
+        <Search size={18} />
+      </button>
+      <button
+        type="button"
+        aria-label="Notifications"
+        className="cursor-pointer text-chalk-300 hover:text-chalk-50"
+      >
+        <Bell size={18} />
+      </button>
+
+      <div className="flex items-center gap-2.5">
+        <Avatar initials={ME.initials} size={32} tone="ball" />
+        <div className="leading-tight">
+          <div className="font-sans text-[13px] font-semibold text-chalk-50">
+            {ME.name}
+          </div>
+          <div className="font-mono text-[10px] tracking-[0.08em] text-chalk-300">
+            {ME.rating} · {ME.club.toUpperCase()}
+          </div>
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/src/components/dashboard/tournament-panel.tsx
+++ b/src/components/dashboard/tournament-panel.tsx
@@ -1,0 +1,234 @@
+import { LayoutGrid, Trophy } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import type { PathResult, PathStep, Tournament, UpNext } from './data'
+import { TOURNAMENT } from './data'
+import { Card, LiveDot, Mono, Overline, Pill } from './primitives'
+
+export function TournamentPanel() {
+  const t: Tournament = TOURNAMENT
+  const hasLive = t.myPath.some((p) => p.result === 'live')
+
+  return (
+    <Card live={hasLive}>
+      <div className="flex items-center gap-4 border-b border-ink-600 px-[22px] py-[18px] pb-4">
+        <div className="flex size-11 shrink-0 items-center justify-center rounded-md bg-ball-500">
+          <Trophy size={22} className="text-ink-950" />
+        </div>
+        <div className="flex-1">
+          <Overline className="mb-1">YOUR ACTIVE TOURNAMENT</Overline>
+          <div className="font-sans text-[20px] font-bold tracking-[-0.01em] text-chalk-50">
+            {t.name}
+          </div>
+          <div className="mt-0.5 font-mono text-[11px] tracking-[0.08em] text-chalk-300">
+            {t.venue.toUpperCase()} · DAY {t.day}/{t.ofDays} ·{' '}
+            {t.format.toUpperCase()}
+          </div>
+        </div>
+        <Button variant="secondary">
+          <LayoutGrid />
+          View bracket
+        </Button>
+      </div>
+
+      <div className="px-[22px] pt-[22px] pb-[18px]">
+        <Overline className="mb-3">
+          YOUR PATH · SEED #{t.bracket.yourSeed} · {t.bracket.toWin} TO THE
+          TITLE
+        </Overline>
+        <div
+          className="grid gap-2"
+          style={{
+            gridTemplateColumns: `repeat(${t.myPath.length}, 1fr)`,
+          }}
+        >
+          {t.myPath.map((p, i) => (
+            <PathStepCard key={i} step={p} />
+          ))}
+        </div>
+      </div>
+
+      <div className="px-[22px] pb-[22px]">
+        <Overline className="mb-2.5">UP NEXT · ON THE FLOOR</Overline>
+        <div className="flex flex-col gap-2">
+          {t.upNext.map((m, i) => (
+            <UpNextRow key={i} m={m} />
+          ))}
+        </div>
+      </div>
+    </Card>
+  )
+}
+
+const PATH_COLORS: Record<
+  PathResult,
+  { bg: string; br: string; fg: string; label: string }
+> = {
+  W: {
+    bg: 'rgba(0,226,154,0.12)',
+    br: 'rgba(0,226,154,0.35)',
+    fg: 'var(--color-serve-500)',
+    label: 'WON',
+  },
+  L: {
+    bg: 'rgba(255,77,109,0.1)',
+    br: 'rgba(255,77,109,0.3)',
+    fg: 'var(--color-loss)',
+    label: 'LOST',
+  },
+  bye: {
+    bg: 'var(--color-ink-800)',
+    br: 'var(--color-ink-600)',
+    fg: 'var(--color-chalk-300)',
+    label: 'BYE',
+  },
+  live: {
+    bg: 'rgba(255,122,26,0.1)',
+    br: 'rgba(255,122,26,0.45)',
+    fg: 'var(--color-ball-500)',
+    label: 'LIVE',
+  },
+  upcoming: {
+    bg: 'var(--color-ink-800)',
+    br: 'var(--color-ink-500)',
+    fg: 'var(--color-chalk-50)',
+    label: 'NEXT',
+  },
+  locked: {
+    bg: 'transparent',
+    br: 'var(--color-ink-600)',
+    fg: 'var(--color-ink-400)',
+    label: '—',
+  },
+}
+
+function PathStepCard({ step }: { step: PathStep }) {
+  const c = PATH_COLORS[step.result]
+  const isLive = step.result === 'live'
+  return (
+    <div
+      className="relative flex min-h-24 flex-col justify-between rounded-md border px-3 pt-3 pb-3.5"
+      style={{
+        background: c.bg,
+        borderColor: c.br,
+        borderStyle: step.result === 'locked' ? 'dashed' : 'solid',
+        boxShadow: isLive ? '0 0 18px rgba(255,122,26,0.15)' : 'none',
+      }}
+    >
+      <div className="flex items-center justify-between">
+        <Mono size={11} color="var(--color-chalk-300)" weight={700}>
+          {step.round}
+        </Mono>
+        <span
+          className="inline-flex items-center gap-1 font-mono text-[9px] font-bold tracking-[0.14em]"
+          style={{ color: c.fg }}
+        >
+          {isLive && <LiveDot color="var(--color-ball-500)" size={6} />}
+          {c.label}
+        </span>
+      </div>
+      <div>
+        <div
+          className="text-[13px] font-medium"
+          style={{
+            color:
+              step.result === 'locked'
+                ? 'var(--color-ink-400)'
+                : 'var(--color-chalk-50)',
+            lineHeight: 1.25,
+          }}
+        >
+          {step.opponent}
+        </div>
+        {step.score && (
+          <Mono
+            size={12}
+            color={c.fg}
+            weight={700}
+            className="mt-0.5 block"
+          >
+            {step.score}
+          </Mono>
+        )}
+        {step.games && (
+          <Mono
+            size={10}
+            color="var(--color-chalk-300)"
+            className="mt-0.5 block"
+          >
+            {step.games}
+          </Mono>
+        )}
+        {step.detail && (
+          <Mono size={10} color={c.fg} className="mt-0.5 block">
+            {step.detail}
+          </Mono>
+        )}
+        {step.eta && (
+          <Mono
+            size={10}
+            color="var(--color-chalk-300)"
+            className="mt-0.5 block"
+          >
+            {step.eta}
+          </Mono>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function UpNextRow({ m }: { m: UpNext }) {
+  return (
+    <div
+      className="grid items-center gap-4 rounded-sm border px-3.5 py-2.5"
+      style={{
+        gridTemplateColumns: '72px 56px 1fr auto',
+        background: m.you ? 'rgba(255,122,26,0.06)' : 'var(--color-ink-900)',
+        borderColor: m.you ? 'rgba(255,122,26,0.3)' : 'var(--color-ink-600)',
+      }}
+    >
+      <Mono
+        size={14}
+        color={m.you ? 'var(--color-ball-500)' : 'var(--color-chalk-50)'}
+        weight={700}
+      >
+        {m.time}
+      </Mono>
+      <div className="font-mono text-[11px] tracking-[0.1em] text-chalk-300">
+        CT {m.court}
+      </div>
+      <div className="flex items-center gap-2.5">
+        <span
+          className={
+            m.you
+              ? 'text-[13px] font-semibold text-chalk-50'
+              : 'text-[13px] font-medium text-chalk-100'
+          }
+        >
+          {m.a}
+        </span>
+        <span className="text-[12px] text-ink-400">vs</span>
+        <span
+          className={
+            m.you
+              ? 'text-[13px] font-semibold text-chalk-50'
+              : 'text-[13px] font-medium text-chalk-100'
+          }
+        >
+          {m.b}
+        </span>
+        <Pill tone="ghost" className="ml-1.5">
+          {m.round}
+        </Pill>
+        {m.you && <Pill tone="ball">YOU</Pill>}
+      </div>
+      <Mono
+        size={11}
+        color="var(--color-chalk-300)"
+        className="text-right"
+      >
+        {m.note ?? (m.you ? 'your next match' : '')}
+      </Mono>
+    </div>
+  )
+}

--- a/src/components/dashboard/tournament-panel.tsx
+++ b/src/components/dashboard/tournament-panel.tsx
@@ -1,5 +1,6 @@
 import { LayoutGrid, Trophy } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 import type { PathResult, PathStep, Tournament, UpNext } from './data'
 import { TOURNAMENT } from './data'
 import { Card, LiveDot, Mono, Overline, Pill } from './primitives'
@@ -61,42 +62,37 @@ export function TournamentPanel() {
 
 const PATH_COLORS: Record<
   PathResult,
-  { bg: string; br: string; fg: string; label: string }
+  { container: string; accent: string; label: string }
 > = {
   W: {
-    bg: 'rgba(0,226,154,0.12)',
-    br: 'rgba(0,226,154,0.35)',
-    fg: 'var(--color-serve-500)',
+    container: 'bg-serve-500/12 border-serve-500/35',
+    accent: 'text-serve-500',
     label: 'WON',
   },
   L: {
-    bg: 'rgba(255,77,109,0.1)',
-    br: 'rgba(255,77,109,0.3)',
-    fg: 'var(--color-loss)',
+    container: 'bg-loss/10 border-loss/30',
+    accent: 'text-loss',
     label: 'LOST',
   },
   bye: {
-    bg: 'var(--color-ink-800)',
-    br: 'var(--color-ink-600)',
-    fg: 'var(--color-chalk-300)',
+    container: 'bg-ink-800 border-ink-600',
+    accent: 'text-chalk-300',
     label: 'BYE',
   },
   live: {
-    bg: 'rgba(255,122,26,0.1)',
-    br: 'rgba(255,122,26,0.45)',
-    fg: 'var(--color-ball-500)',
+    container:
+      'bg-ball-500/10 border-ball-500/45 shadow-[0_0_18px_rgba(255,122,26,0.15)]',
+    accent: 'text-ball-500',
     label: 'LIVE',
   },
   upcoming: {
-    bg: 'var(--color-ink-800)',
-    br: 'var(--color-ink-500)',
-    fg: 'var(--color-chalk-50)',
+    container: 'bg-ink-800 border-ink-500',
+    accent: 'text-chalk-50',
     label: 'NEXT',
   },
   locked: {
-    bg: 'transparent',
-    br: 'var(--color-ink-600)',
-    fg: 'var(--color-ink-400)',
+    container: 'bg-transparent border-ink-600 border-dashed',
+    accent: 'text-ink-400',
     label: '—',
   },
 }
@@ -104,23 +100,24 @@ const PATH_COLORS: Record<
 function PathStepCard({ step }: { step: PathStep }) {
   const c = PATH_COLORS[step.result]
   const isLive = step.result === 'live'
+  const opponentColor =
+    step.result === 'locked' ? 'text-ink-400' : 'text-chalk-50'
   return (
     <div
-      className="relative flex min-h-24 flex-col justify-between rounded-md border px-3 pt-3 pb-3.5"
-      style={{
-        background: c.bg,
-        borderColor: c.br,
-        borderStyle: step.result === 'locked' ? 'dashed' : 'solid',
-        boxShadow: isLive ? '0 0 18px rgba(255,122,26,0.15)' : 'none',
-      }}
+      className={cn(
+        'relative flex min-h-24 flex-col justify-between rounded-md border px-3 pt-3 pb-3.5',
+        c.container,
+      )}
     >
       <div className="flex items-center justify-between">
-        <Mono size={11} color="var(--color-chalk-300)" weight={700}>
+        <Mono size={11} weight={700} className="text-chalk-300">
           {step.round}
         </Mono>
         <span
-          className="inline-flex items-center gap-1 font-mono text-[9px] font-bold tracking-[0.14em]"
-          style={{ color: c.fg }}
+          className={cn(
+            'inline-flex items-center gap-1 font-mono text-[9px] font-bold tracking-[0.14em]',
+            c.accent,
+          )}
         >
           {isLive && <LiveDot color="var(--color-ball-500)" size={6} />}
           {c.label}
@@ -128,47 +125,30 @@ function PathStepCard({ step }: { step: PathStep }) {
       </div>
       <div>
         <div
-          className="text-[13px] font-medium"
-          style={{
-            color:
-              step.result === 'locked'
-                ? 'var(--color-ink-400)'
-                : 'var(--color-chalk-50)',
-            lineHeight: 1.25,
-          }}
+          className={cn(
+            'text-[13px] font-medium leading-[1.25]',
+            opponentColor,
+          )}
         >
           {step.opponent}
         </div>
         {step.score && (
-          <Mono
-            size={12}
-            color={c.fg}
-            weight={700}
-            className="mt-0.5 block"
-          >
+          <Mono size={12} weight={700} className={cn('mt-0.5 block', c.accent)}>
             {step.score}
           </Mono>
         )}
         {step.games && (
-          <Mono
-            size={10}
-            color="var(--color-chalk-300)"
-            className="mt-0.5 block"
-          >
+          <Mono size={10} className="mt-0.5 block text-chalk-300">
             {step.games}
           </Mono>
         )}
         {step.detail && (
-          <Mono size={10} color={c.fg} className="mt-0.5 block">
+          <Mono size={10} className={cn('mt-0.5 block', c.accent)}>
             {step.detail}
           </Mono>
         )}
         {step.eta && (
-          <Mono
-            size={10}
-            color="var(--color-chalk-300)"
-            className="mt-0.5 block"
-          >
+          <Mono size={10} className="mt-0.5 block text-chalk-300">
             {step.eta}
           </Mono>
         )}
@@ -178,19 +158,24 @@ function PathStepCard({ step }: { step: PathStep }) {
 }
 
 function UpNextRow({ m }: { m: UpNext }) {
+  const rowTone = m.you
+    ? 'bg-ball-500/6 border-ball-500/30'
+    : 'bg-ink-900 border-ink-600'
+  const nameTone = m.you
+    ? 'text-[13px] font-semibold text-chalk-50'
+    : 'text-[13px] font-medium text-chalk-100'
   return (
     <div
-      className="grid items-center gap-4 rounded-sm border px-3.5 py-2.5"
-      style={{
-        gridTemplateColumns: '72px 56px 1fr auto',
-        background: m.you ? 'rgba(255,122,26,0.06)' : 'var(--color-ink-900)',
-        borderColor: m.you ? 'rgba(255,122,26,0.3)' : 'var(--color-ink-600)',
-      }}
+      className={cn(
+        'grid items-center gap-4 rounded-sm border px-3.5 py-2.5',
+        rowTone,
+      )}
+      style={{ gridTemplateColumns: '72px 56px 1fr auto' }}
     >
       <Mono
         size={14}
-        color={m.you ? 'var(--color-ball-500)' : 'var(--color-chalk-50)'}
         weight={700}
+        className={m.you ? 'text-ball-500' : 'text-chalk-50'}
       >
         {m.time}
       </Mono>
@@ -198,35 +183,15 @@ function UpNextRow({ m }: { m: UpNext }) {
         CT {m.court}
       </div>
       <div className="flex items-center gap-2.5">
-        <span
-          className={
-            m.you
-              ? 'text-[13px] font-semibold text-chalk-50'
-              : 'text-[13px] font-medium text-chalk-100'
-          }
-        >
-          {m.a}
-        </span>
+        <span className={nameTone}>{m.a}</span>
         <span className="text-[12px] text-ink-400">vs</span>
-        <span
-          className={
-            m.you
-              ? 'text-[13px] font-semibold text-chalk-50'
-              : 'text-[13px] font-medium text-chalk-100'
-          }
-        >
-          {m.b}
-        </span>
+        <span className={nameTone}>{m.b}</span>
         <Pill tone="ghost" className="ml-1.5">
           {m.round}
         </Pill>
         {m.you && <Pill tone="ball">YOU</Pill>}
       </div>
-      <Mono
-        size={11}
-        color="var(--color-chalk-300)"
-        className="text-right"
-      >
+      <Mono size={11} className="text-right text-chalk-300">
         {m.note ?? (m.you ? 'your next match' : '')}
       </Mono>
     </div>

--- a/src/routes/dashboard.tsx
+++ b/src/routes/dashboard.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react'
+import { createFileRoute } from '@tanstack/react-router'
+import { ClubFeed } from '@/components/dashboard/club-feed'
+import type { DashboardState } from '@/components/dashboard/data'
+import { DASHBOARD_STATES, LIVE_MATCH } from '@/components/dashboard/data'
+import { DashboardFooter } from '@/components/dashboard/footer'
+import { ContextRow, Greeting } from '@/components/dashboard/greeting'
+import { IdleHero } from '@/components/dashboard/idle-hero'
+import { LiveMatchScoreboard } from '@/components/dashboard/live-match'
+import { RatingPanel } from '@/components/dashboard/rating-panel'
+import { RecentMatches } from '@/components/dashboard/recent-matches'
+import { TDPanel } from '@/components/dashboard/td-panel'
+import { TopBar } from '@/components/dashboard/topbar'
+import { TournamentPanel } from '@/components/dashboard/tournament-panel'
+
+export const Route = createFileRoute('/dashboard')({
+  component: DashboardPage,
+})
+
+function DashboardPage() {
+  const [state, setState] = useState<DashboardState>('in_tournament_playing')
+
+  const cycleState = () => {
+    const i = DASHBOARD_STATES.indexOf(state)
+    setState(DASHBOARD_STATES[(i + 1) % DASHBOARD_STATES.length])
+  }
+
+  const showLiveFullBleed =
+    state === 'live_match' || state === 'in_tournament_playing'
+  const showLiveCompact = state === 'td_playing'
+  const showTournament =
+    state === 'in_tournament' || state === 'in_tournament_playing'
+  const showTD = state === 'td' || state === 'td_playing'
+  const showIdleHero = state === 'idle'
+
+  return (
+    <div className="min-h-svh bg-ink-950">
+      <TopBar state={state} onCycleState={cycleState} />
+
+      {showLiveFullBleed && (
+        <LiveMatchScoreboard
+          match={LIVE_MATCH}
+          onExit={() => setState('in_tournament')}
+        />
+      )}
+
+      {!showLiveFullBleed && <Greeting state={state} />}
+      {showLiveFullBleed && <ContextRow state={state} />}
+
+      <div
+        className="grid items-start gap-6 px-10 pt-2 pb-14"
+        style={{
+          gridTemplateColumns: 'minmax(0, 2.4fr) minmax(340px, 1fr)',
+        }}
+      >
+        <div className="flex flex-col gap-5">
+          {showIdleHero && <IdleHero />}
+          {showTD && <TDPanel />}
+          {showLiveCompact && (
+            <LiveMatchScoreboard
+              match={LIVE_MATCH}
+              compact
+              onExit={() => setState('td')}
+            />
+          )}
+          {showTournament && <TournamentPanel />}
+          <RecentMatches />
+        </div>
+
+        <div className="flex flex-col gap-5">
+          <RatingPanel />
+          <ClubFeed />
+        </div>
+      </div>
+
+      <DashboardFooter />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds `/dashboard` route that rearranges around six user states (idle, live_match, in_tournament, in_tournament_playing, td, td_playing), cycleable via the STATE pill in the top bar.
- Implements the Claude Design handoff as idiomatic React + Tailwind v4 components, reusing the existing `@theme` tokens, `Button` primitive, `Separator`, and `animate-ball-pulse` utility.
- New components live under `src/components/dashboard/` — `data.ts` (mock fixtures + types), `primitives.tsx` (Pill, Avatar, Card, Overline, SectionHeader, Mono, MiniStat, LiveDot, TextLink), plus state panels (IdleHero, TournamentPanel, TDPanel, LiveMatchScoreboard + compact hero card), persistent right column (RatingPanel w/ sparkline, RecentMatches, ClubFeed), and shell pieces (TopBar, Greeting, ContextRow, DashboardFooter).

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm run build` succeeds; dashboard chunk ~70KB / ~21KB gzip
- [ ] `npm run dev`, navigate to `/dashboard`, click the STATE pill to cycle through all six states and confirm:
  - [ ] idle → IdleHero with ball decoration + 3 CTAs
  - [ ] live_match → full-bleed scoreboard takeover (with ContextRow below)
  - [ ] in_tournament → TournamentPanel showing path + up-next
  - [ ] in_tournament_playing → full-bleed scoreboard *plus* TournamentPanel
  - [ ] td → TDPanel with stat strip, needs-you queue, courts grid
  - [ ] td_playing → compact live hero card + TDPanel (full-bleed off so TD duties stay visible)
- [ ] Right column (RatingPanel sparkline, RecentMatches, ClubFeed) renders in all states
- [ ] Top-bar icon buttons (Search, Bell) and state pill are keyboard-focusable with aria-labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)