### PR TITLE
Route API calls through /api prefix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,3 @@
-# Base URL for the FortyMM API. Leave empty in dev to route through the
-# Vite proxy (see vite.config.ts → server.proxy['/v1']).
-VITE_API_URL=
-
 # Set to "true" to start the MSW worker in the browser and serve mocked
 # responses instead of hitting the real API. Default: off.
 VITE_USE_MOCKS=false

--- a/.env.test
+++ b/.env.test
@@ -1,1 +1,0 @@
-VITE_API_URL=http://localhost

--- a/README.md
+++ b/README.md
@@ -45,11 +45,19 @@ services:
 
 ### Behind a reverse proxy
 
+The bundle calls the API at the relative path `/api/*`, so your reverse proxy
+must route `/api/*` to the FortyMM API and everything else to this container.
+
 Caddy:
 
 ```
 fortymm.example.com {
-    reverse_proxy localhost:8080
+    handle /api/* {
+        reverse_proxy api.internal:4001
+    }
+    handle {
+        reverse_proxy localhost:8080
+    }
 }
 ```
 
@@ -60,6 +68,13 @@ server {
     listen 443 ssl;
     server_name fortymm.example.com;
 
+    location /api/ {
+        proxy_pass http://api.internal:4001/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location / {
         proxy_pass http://localhost:8080;
         proxy_set_header Host $host;
@@ -69,7 +84,9 @@ server {
 }
 ```
 
-The container itself serves plain HTTP on port 80 — terminate TLS at your reverse proxy.
+The trailing slash on `proxy_pass http://api.internal:4001/` strips the
+`/api/` prefix so the upstream sees `/v1/...`. Terminate TLS at your reverse
+proxy — the container itself serves plain HTTP on port 80.
 
 ### Build the image locally
 

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -1,9 +1,7 @@
 import createClient from 'openapi-fetch'
 import type { paths } from './schema'
 
-const baseUrl = import.meta.env.VITE_API_URL ?? ''
-
 export const api = createClient<paths>({
-  baseUrl,
+  baseUrl: `${location.origin}/api`,
   fetch: (...args) => globalThis.fetch(...args),
 })

--- a/src/lib/api/session.test.tsx
+++ b/src/lib/api/session.test.tsx
@@ -21,7 +21,7 @@ function makeWrapper() {
 describe('useSession', () => {
   it('returns the session from POST /v1/session', async () => {
     server.use(
-      http.post('*/v1/session', () =>
+      http.post('*/api/v1/session', () =>
         HttpResponse.json({
           token: 'test-token',
           user: {
@@ -47,7 +47,7 @@ describe('useSession', () => {
     useTokenStore.setState({ token: 'stored-token' })
     let receivedAuthHeader: string | null = null
     server.use(
-      http.post('*/v1/session', ({ request }) => {
+      http.post('*/api/v1/session', ({ request }) => {
         receivedAuthHeader = request.headers.get('authorization')
         return HttpResponse.json({
           token: 'next-token',
@@ -63,7 +63,7 @@ describe('useSession', () => {
 
   it('persists the response token', async () => {
     server.use(
-      http.post('*/v1/session', () =>
+      http.post('*/api/v1/session', () =>
         HttpResponse.json({
           token: 'rotated-token',
           user: { id: '00000000-0000-0000-0000-000000000003', username: 'tester' },

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -12,7 +12,7 @@ export const handlers = [
     }
     return HttpResponse.json(player)
   }),
-  http.post('*/v1/session', () => {
+  http.post('*/api/v1/session', () => {
     const session: Session = {
       token: faker.string.alphanumeric(32),
       user: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,11 @@ import tailwindcss from '@tailwindcss/vite'
 import { tanstackRouter } from '@tanstack/router-plugin/vite'
 
 const apiProxy = {
-  '/v1': { target: 'http://127.0.0.1:4001', changeOrigin: true },
+  '/api': {
+    target: 'http://127.0.0.1:4001',
+    changeOrigin: true,
+    rewrite: (p: string) => p.replace(/^\/api/, ''),
+  },
 }
 
 // https://vite.dev/config/


### PR DESCRIPTION
## Summary
- Bundle now calls `/api/v1/...` (same-origin, relative). Vite proxies `/api` → local FastAPI in dev; in production an outer reverse proxy fronts both the web client and the API.
- `VITE_API_URL` is gone — the prefix is an app-level constant; varying it is a deploy-side proxy concern. `.env.test` is deleted; `.env.example` keeps only `VITE_USE_MOCKS`.
- README's "Behind a reverse proxy" Caddy and nginx snippets now show both `/api/*` → API and `/*` → web container routes.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` — 10/10 pass; `session.test.tsx` exercises the new `*/api/v1/session` MSW path
- [x] `npm run build`
- [ ] `npm run dev` against a local `fortymm-api` on `127.0.0.1:4001` — confirm `POST /api/v1/session` returns 200 through the Vite proxy
- [ ] `npm run e2e` in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)